### PR TITLE
Added `derive_surface` and `get_positions` with tests.

### DIFF
--- a/membrane_curvature/core.py
+++ b/membrane_curvature/core.py
@@ -5,7 +5,7 @@ MDAkit for Membrane Curvature
 Handles the primary functions
 """
 
-from .lib.mods import core_fast_leaflet, gaussian_curvature, mean_curvature
+from .lib.mods import derive_surface, gaussian_curvature, mean_curvature
 import time
 import MDAnalysis as mda
 import math
@@ -32,7 +32,7 @@ def main():
 
     # 4. Save pickles zpo4
     z_Ref = np.zeros([n_cells, n_cells])
-    z_coords = core_fast_leaflet(u, z_Ref, n_cells, selection, max_width)
+    z_coords = derive_surface(n_cells, selection, max_width)
 
     # 5. Calculate curvature
     K = gaussian_curvature(z_coords)

--- a/membrane_curvature/lib/mods.py
+++ b/membrane_curvature/lib/mods.py
@@ -1,27 +1,33 @@
 import numpy as np
 
 
-def derive_surface(n_cells, selection, max_width_x, max_width_y):
+def derive_surface(n_cells_x, n_cells_y, selection, max_width_x, max_width_y):
     """
     Derive surface from AtomGroup positions.
 
     Parameters
     ----------
-    n_cells : int.
-        number of cells in the grid of size `max_width`.
+    n_cells_x : int.
+        number of cells in the grid of size `max_width_x`, `x` axis.
+    n_cells_y : int.
+        number of cells in the grid of size `max_width_y`, `y` axis.
     selection : AtomGroup.
         AtomGroup of reference selection to define the surface
         of the membrane.
-    max_width : float.
-        Maximum width of simulation box. (Determined by simulation box dimensions)
+    max_width_x: float.
+        Maximum width of simulation box in x axis. (Determined by simulation box dimensions)
+    max_width_y: float.
+        Maximum width of simulation box in y axis. (Determined by simulation box dimensions)
 
     Returns
     -------
-    Returns set of z coordinates 
+    z_coordinates: numpy.ndarray
+        Average z-coordinate values. Return Numpy array of floats of
+        shape `(n_cells_x, n_cells_y)`.
 
     """
     coordinates = selection.positions
-    return get_z_surface(coordinates, n_x_bins=n_cells, n_y_bins=n_cells,
+    return get_z_surface(coordinates, n_x_bins=n_cells_x, n_y_bins=n_cells_y,
                          x_range=(0, max_width_x), y_range=(0, max_width_y))
 
 
@@ -31,21 +37,23 @@ def get_z_surface(coordinates, n_x_bins=10, n_y_bins=10, x_range=(0, 100), y_ran
 
     Parameters
     ----------
-    coordinates : tuple.
-        Numpy.ndarray with shape=(n_atoms, 3).
+    coordinates : numpy.ndarray 
+        Coordinates of AtomGroup. Numpy array of shape=(n_atoms, 3).
     n_x_bins : int.
-        Number of bins in grid in the x dimension. 
+        Number of bins in grid in the `x` dimension. 
     n_y_bins : int.
-        Number of bins in grid in the y dimension. 
-    x_range : tuple
-        Range of indexes in grid in the x dimension with shape=(0, max_width_x).
-    y_range : tuple
-        Range of indexes in grid in the y dimension with shape=(0, max_width_y)
+        Number of bins in grid in the `y` dimension. 
+    x_range : tuple of (float, float)
+        Range of indexes in grid in the `x` dimension with shape=(2,).
+    y_range : tuple of (float, float)
+        Range of indexes in grid in the `y` dimension with shape=(2,).
 
 
     Returns
     -------
-    Returns surface derived from z coordinates in grid of `n_x_bins` x `n_y_bins` dimensions.
+    z_surface: numpy.ndarray 
+        Surface derived from set of coordinates in grid of `x_range, y_range` dimensions.
+        Returns Numpy array of floats of shape (`n_x_bins`, `n_y_bins`)
 
     """
 
@@ -95,9 +103,8 @@ def avg_unit_cell(z_ref, grid_z_coordinates, grid_norm_unit):
 
     """
 
-    normed = grid_norm_unit > 0
+    grid_norm_unit = np.where(grid_norm_unit > 0, grid_norm_unit, np.nan)
     z_ref = grid_z_coordinates / grid_norm_unit
-    z_ref[~normed] = np.nan
 
     return z_ref
 

--- a/membrane_curvature/lib/mods.py
+++ b/membrane_curvature/lib/mods.py
@@ -44,10 +44,9 @@ def get_z_surface(coordinates, n_x_bins=10, n_y_bins=10, x_range=(0, 100), y_ran
     n_y_bins : int.
         Number of bins in grid in the `y` dimension. 
     x_range : tuple of (float, float)
-        Range of indexes in grid in the `x` dimension with shape=(2,).
+        Range of coordinates (min, max) in the `x` dimension with shape=(2,).
     y_range : tuple of (float, float)
-        Range of indexes in grid in the `y` dimension with shape=(2,).
-
+        Range of coordinates (min, max) in the `y` dimension with shape=(2,). 
 
     Returns
     -------

--- a/membrane_curvature/lib/mods.py
+++ b/membrane_curvature/lib/mods.py
@@ -13,20 +13,20 @@ def derive_surface(n_cells, selection, max_width):
     selection : AtomGroup
         AtomGroup of reference selection to define the surface
         of the membrane.
-    max_width : int.
-        Maximum width of simulation box.
+    max_width : float.
+        Maximum width of simulation box. (Determined by simulation box dimensions)
 
     Returns
     -------
     Returns set of z coordinates in grid.
 
     """
-    NM_TO_ANGSTROM = 10  # Factor needed temporarily until we can make this code unit-aware or unitless
+
     z_ref = np.zeros((n_cells, n_cells))
     grid_z_coordinates = np.zeros((n_cells, n_cells))
     grid_norm_unit = np.zeros([n_cells, n_cells])
 
-    # max_width *= NM_TO_ANGSTROM # scaling the max width of the box. Will remove
+    
     factor = np.float32(n_cells / max_width)
 
     cell_xy_floor = np.int32(selection.positions[:, :2] * factor)

--- a/membrane_curvature/lib/mods.py
+++ b/membrane_curvature/lib/mods.py
@@ -57,7 +57,6 @@ def get_z_surface(coordinates, n_x_bins=10, n_y_bins=10, x_range=(0, 100), y_ran
 
     """
 
-    z_ref = np.zeros((n_x_bins, n_y_bins))
     grid_z_coordinates = np.zeros((n_x_bins, n_y_bins))
     grid_norm_unit = np.zeros((n_x_bins, n_y_bins))
 
@@ -78,12 +77,12 @@ def get_z_surface(coordinates, n_x_bins=10, n_y_bins=10, x_range=(0, 100), y_ran
         except IndexError:
             print("Atom outside grid boundaries. Skipping atom.")
 
-    z_surface = avg_unit_cell(z_ref, grid_z_coordinates, grid_norm_unit)
+    z_surface = normalized_grid(grid_z_coordinates, grid_norm_unit)
 
     return z_surface
 
 
-def avg_unit_cell(z_ref, grid_z_coordinates, grid_norm_unit):
+def normalized_grid(grid_z_coordinates, grid_norm_unit):
     """
     Calculates average z coordinate in unit cell
 
@@ -104,9 +103,9 @@ def avg_unit_cell(z_ref, grid_z_coordinates, grid_norm_unit):
     """
 
     grid_norm_unit = np.where(grid_norm_unit > 0, grid_norm_unit, np.nan)
-    z_ref = grid_z_coordinates / grid_norm_unit
+    z_normalized = grid_z_coordinates / grid_norm_unit
 
-    return z_ref
+    return z_normalized
 
 
 def gaussian_curvature(Z):

--- a/membrane_curvature/lib/mods.py
+++ b/membrane_curvature/lib/mods.py
@@ -3,8 +3,8 @@ import numpy as np
 
 
 def get_positions(index):
-    """ 
-    Get positions of bead by index 
+    """
+    Get positions of bead by index
 
     Parameters
     ----------
@@ -16,7 +16,7 @@ def get_positions(index):
 
 
 def grid_map(coords, factor):
-    """ 
+    """
     Maps (x,y) coordinates to unit cell in grid.
 
     Parameters

--- a/membrane_curvature/lib/mods.py
+++ b/membrane_curvature/lib/mods.py
@@ -27,7 +27,7 @@ def derive_surface(n_cells, selection, max_width):
     grid_norm_unit = np.zeros([n_cells, n_cells])
 
     
-    factor = np.float32(n_cells / max_width)
+    factor = n_cells / max_width
 
     cell_xy_floor = np.int32(selection.positions[:, :2] * factor)
     z_coordinate = selection.positions[:, 2]

--- a/membrane_curvature/lib/mods.py
+++ b/membrane_curvature/lib/mods.py
@@ -87,7 +87,7 @@ def avg_unit_cell(z_ref, n_cells, grid_z_coordinates, grid_norm_unit):
         if grid_norm_unit[i, j] > 0:
             z_ref[i, j] += grid_z_coordinates[i, j] / grid_norm_unit[i, j]
         else:
-            z_ref[i, j] += np.nan
+            z_ref[i, j] = np.nan
 
     return z_ref
 

--- a/membrane_curvature/lib/mods.py
+++ b/membrane_curvature/lib/mods.py
@@ -26,10 +26,11 @@ def derive_surface(n_cells, selection, max_width):
     grid_z_coordinates = np.zeros((n_cells, n_cells))
     grid_norm_unit = np.zeros([n_cells, n_cells])
 
-    factor = np.float32(n_cells / max_width * NM_TO_ANGSTROM)
+    # max_width *= NM_TO_ANGSTROM # scaling the max width of the box. Will remove
+    factor = np.float32(n_cells / max_width)
 
-    cell_xy_floor = np.int32(selection.positions[:, :2] / factor)
-    z_coordinate = selection.positions[:, 2] / factor * NM_TO_ANGSTROM
+    cell_xy_floor = np.int32(selection.positions[:, :2] * factor)
+    z_coordinate = selection.positions[:, 2]
 
     for (l, m), z in zip(cell_xy_floor, z_coordinate):
 

--- a/membrane_curvature/tests/test_mdakit_membcurv.py
+++ b/membrane_curvature/tests/test_mdakit_membcurv.py
@@ -310,4 +310,4 @@ def test_avg_unit_cell_more_beads(n_cells, grid_z_coords, grid_norm, grid_avg):
 def test_derive_surface(n_cells, max_width, dummy_beads, z_avg):
     surf = derive_surface(n_cells, dummy_beads, max_width)
     for cell in range(n_cells):
-        assert_almost_equal( z_avg[cell], z_avg[cell] )
+        assert_almost_equal(z_avg[cell], z_avg[cell])

--- a/membrane_curvature/tests/test_mdakit_membcurv.py
+++ b/membrane_curvature/tests/test_mdakit_membcurv.py
@@ -3,7 +3,7 @@ Unit and regression test for the membrane_curvature package.
 """
 
 import pytest
-from ..lib.mods import mean_curvature, gaussian_curvature, avg_unit_cell, derive_surface, get_z_surface
+from ..lib.mods import mean_curvature, gaussian_curvature, normalized_grid, derive_surface, get_z_surface
 import numpy as np
 from numpy.testing import assert_almost_equal
 import MDAnalysis as mda
@@ -150,28 +150,25 @@ def test_mean_curvature_all():
         assert_almost_equal(h, h_test)
 
 
-@pytest.mark.parametrize('n_cells, z_ref, grid_z_coords', [
-    (3, np.zeros((3, 3)), np.full((3, 3), 10.)),
-    (3, np.zeros((3, 3)), np.array([[10., 20., 30.], [10., 20., 30.], [10., 20., 30.]], dtype=float))
+@pytest.mark.parametrize('n_cells, grid_z_coords', [
+    (3, np.full((3, 3), 10.)),
+    (3, np.array([[10., 20., 30.], [10., 20., 30.], [10., 20., 30.]], dtype=float))
 ])
-def test_avg_unit_cell_identity_other_values(n_cells, z_ref, grid_z_coords):
+def test_normalized_grid_identity_other_values(n_cells, grid_z_coords):
     unit = np.ones([n_cells, n_cells])
-    z_avg = avg_unit_cell(z_ref, grid_z_coords, unit)
+    z_avg = normalized_grid(grid_z_coords, unit)
     assert_almost_equal(z_avg, grid_z_coords)
 
 
-def test_avg_unit_cell_more_beads():
-    # number of cells
-    n_cells = 3
+def test_normalized_grid_more_beads():
     # sum of z coordinate in grid,
     grid_z_coords = np.full((3, 3), 10.)
     # grid number of beads per unit
-    normalized_grid = np.array([[2., 1., 1.], [1., 2., 1.], [1., 1., 2.]])
+    norm_grid = np.array([[2., 1., 1.], [1., 2., 1.], [1., 1., 2.]])
     # avg z coordinate in grid
-    expected_surface = np.array([[5., 10., 10.], [10., 5., 10.], [10., 10., 5.]])
-    z_ref = np.zeros([n_cells, n_cells])
-    average_surface = avg_unit_cell(z_ref, grid_z_coords, normalized_grid)
-    assert_almost_equal(average_surface, expected_surface)
+    expected_normalized_surface = np.array([[5., 10., 10.], [10., 5., 10.], [10., 10., 5.]])
+    average_surface = normalized_grid(grid_z_coords, norm_grid)
+    assert_almost_equal(average_surface, expected_normalized_surface)
 
 
 def test_derive_surface(small_grofile):

--- a/membrane_curvature/tests/test_mdakit_membcurv.py
+++ b/membrane_curvature/tests/test_mdakit_membcurv.py
@@ -4,7 +4,7 @@ Unit and regression test for the membrane_curvature package.
 
 # Import package, test suite, and other packages as needed
 import pytest
-from ..lib.mods import mean_curvature, gaussian_curvature, grid_map, get_positions, avg_unit_cell, derive_surface
+from ..lib.mods import mean_curvature, gaussian_curvature, avg_unit_cell, derive_surface
 import numpy as np
 from numpy.testing import assert_almost_equal
 import MDAnalysis as mda
@@ -120,6 +120,13 @@ MEMBRANE_CURVATURE_DATA = {
 }
 
 
+@pytest.fixture
+def small_grofile():
+    u = mda.Universe(GRO_PO4_SMALL)
+    sel = u.select_atoms('name PO4')
+    return sel
+
+
 def test_gaussian_curvature_small():
     K_test = gaussian_curvature(MEMBRANE_CURVATURE_DATA['z_ref']['small'])
     for k, k_test in zip(MEMBRANE_CURVATURE_DATA['gaussian_curvature']['small'], K_test):
@@ -144,99 +151,6 @@ def test_mean_curvature_all():
         assert_almost_equal(h, h_test)
 
 
-def test_core_fast_leaflets():
-    n_cells, max_width = 3, 3
-    z_calc = np.zeros([n_cells, n_cells])
-    u = mda.Universe(GRO_PO4_SMALL, XTC_PO4_SMALL)
-    selection = u.select_atoms('index 0:3')
-    core_fast_leaflet(u, z_calc, n_cells, selection, max_width)
-    for z, z_test in zip(MEMBRANE_CURVATURE_DATA['grid']['small']['upper'], z_calc):
-        print(z, z_test)
-        assert_almost_equal(z, z_test)
-
-
-@pytest.mark.parametrize('factor', [1, 2])
-@pytest.mark.parametrize('dummy_coord', [
-    # dummy coordinates (x,y) in grid of 3x3
-    (0, 0), (1, 0), (2, 0),
-    (0, 1), (1, 1), (2, 1),
-    (0, 2), (1, 2), (2, 2),
-    # dummy coordinates (x,y) in grid of 5x5
-    (0, 0), (1, 0), (2, 0), (3, 0), (4, 0),
-    (0, 1), (1, 1), (2, 1), (3, 1), (4, 1),
-    (0, 2), (1, 2), (2, 2), (3, 2), (4, 2),
-    (0, 3), (1, 3), (2, 3), (3, 3), (4, 3),
-    (0, 4), (1, 4), (2, 4), (3, 4), (4, 4)
-])
-def test_grid_map_grids(dummy_coord, factor):
-    cell = (dummy_coord[0] * factor, dummy_coord[1] * factor)
-    assert grid_map(dummy_coord, factor) == cell
-
-
-@pytest.mark.parametrize('dummy_coords, expected', [
-    # dummy coordinates (x,y)
-    (0, 0), (-1, 0), (2, 0),
-    (0, 1), (-1, 1), (2, 1),
-    (0, 2), (-1, 2), (2, 2),
-    # should map to
-    (0, 0), (2, 0), (2, 0),
-    (0, 1), (2, 1), (2, 1),
-    (0, 2), (2, 2), (2, 2)])
-@pytest.mark.xfail(reason='Incorrect mapping of negative coordinates')
-def test_grid_map_9grid_negative(dummy_coords, expected):
-    assert grid_map(dummy_coords, 1) == expected
-@pytest.mark.parametrize('dummy_systems', [(
-    # dummy coordinates (x,y) in grid of 3x3
-    ((0, 0), (1, 0), (2, 0),
-     (0, 1), (1, 1), (2, 1),
-     (0, 2), (1, 2), (2, 2)),
-    # dummy coordinates (x,y) in grid of 5x5
-    ((0, 0), (1, 0), (2, 0), (3, 0), (4, 0),
-     (0, 1), (1, 1), (2, 1), (3, 1), (4, 1),
-     (0, 2), (1, 2), (2, 2), (3, 2), (4, 2),
-     (0, 3), (1, 3), (2, 3), (3, 3), (4, 3),
-     (0, 4), (1, 4), (2, 4), (3, 4), (4, 4)))])
-def test_grid_map_grids(dummy_systems):
-    # map to grid of 3 unit cells
-    for grid in dummy_systems:
-        factor = np.float32(np.sqrt(len(grid)) / np.sqrt(len(grid)))
-        for dummy_coord in grid:
-            assert grid_map(dummy_coord, factor) == dummy_coord
-    # map to grid of 6 unit cells
-    for grid in dummy_systems:
-        factor = np.float32(np.sqrt(len(grid))*2 / np.sqrt(len(grid)))
-        for dummy_coord in grid:
-            assert grid_map(dummy_coord, factor) == (dummy_coord[0]*2, dummy_coord[1]*2)
-
-
-@pytest.mark.parametrize('dummy_coordinates, test_mapper, n_cells, max_width', [(
-    # dummy coordinates (x,y)
-    ((0, 0), (-1, 0), (2, 0),
-     (0, 1), (-1, 1), (2, 1),
-     (0, 2), (-1, 2), (2, 2)),
-    # should map to
-    ((0, 0), (2, 0), (2, 0),
-     (0, 1), (2, 1), (2, 1),
-     (0, 2), (2, 2), (2, 2)),
-    3, 3),
-])
-@pytest.mark.xfail(reason='Incorrect mapping of negative coordinates')
-def test_grid_map_9grid_negative(dummy_coordinates, test_mapper, n_cells, max_width):
-    factor = np.float32(n_cells / max_width)
-    for dummy_coord in dummy_coordinates:
-        assert test_mapper(dummy_coord) == grid_map(dummy_coord, factor)
-
-
-@pytest.mark.parametrize('dummy_coordinates', [(
-    # dummy coordinates (x, y, z)
-    ((0, 0, 10), (1, 0, 10), (2, 0, 10),
-     (0, 1, 10), (1, 1, 10), (2, 1, 10),
-     (0, 2, 10), (1, 2, 10), (2, 2, 10)))])
-def test_get_positions(dummy_coordinates):
-    for index, dummy_coord in enumerate(dummy_coordinates):
-        assert dummy_coordinates[index] == get_positions(dummy_coord)
-
-
 @pytest.mark.parametrize('n_cells, grid_z_coords, unit', [(
     # number of cells
     3,
@@ -251,7 +165,7 @@ def test_get_positions(dummy_coordinates):
 def test_avg_unit_cell_identity(n_cells, grid_z_coords, unit):
     z_ref = np.zeros([n_cells, n_cells])
     unit = np.ones([n_cells, n_cells])
-    unit_cell = avg_unit_cell(z_ref, n_cells, grid_z_coords, unit)
+    unit_cell = avg_unit_cell(z_ref, grid_z_coords, unit)
     for z_position, cell in zip(unit_cell, range(n_cells)):
         assert z_position[cell] == 10.
 
@@ -267,7 +181,7 @@ def test_avg_unit_cell_identity(n_cells, grid_z_coords, unit):
 def test_avg_unit_cell_identity_other_values(n_cells, grid_z_coords):
     z_ref = np.zeros([n_cells, n_cells])
     unit = np.ones([n_cells, n_cells])
-    z_avg = avg_unit_cell(z_ref, n_cells, grid_z_coords, unit)
+    z_avg = avg_unit_cell(z_ref, grid_z_coords, unit)
     for cell in range(n_cells):
         assert_almost_equal(z_avg[cell], grid_z_coords[cell])
 
@@ -290,24 +204,70 @@ def test_avg_unit_cell_identity_other_values(n_cells, grid_z_coords):
 )])
 def test_avg_unit_cell_more_beads(n_cells, grid_z_coords, grid_norm, grid_avg):
     z_ref = np.zeros([n_cells, n_cells])
-    unit_cell = avg_unit_cell(z_ref, n_cells, grid_z_coords, grid_norm)
+    unit_cell = avg_unit_cell(z_ref, grid_z_coords, grid_norm)
     for cell in range(n_cells):
         assert_almost_equal(unit_cell[cell], grid_avg[cell])
 
 
-@pytest.mark.parametrize('n_cells, max_width, dummy_beads, z_avg', [(
+@pytest.mark.parametrize('n_cells, max_width, z_avg', [(
     # number of cells
     3, 3,
-    # dummy coordinates (x, y, z)
-    ((0, 0, 10), (1, 0, 10), (2, 0, 10),
-     (0, 1, 10), (1, 1, 10), (2, 1, 10),
-     (0, 2, 10), (1, 2, 10), (2, 2, 10)),
     # z ref of surface
     # z coordinate in grid
-    np.array([[10., 10., 10.],
-              [10., 10., 10.],
-              [10., 10., 10.]]))])
-def test_derive_surface(n_cells, max_width, dummy_beads, z_avg):
-    surf = derive_surface(n_cells, dummy_beads, max_width)
-    for cell in range(n_cells):
-        assert_almost_equal(z_avg[cell], z_avg[cell])
+    np.array(([150., 150., 120.],
+              [150., 120., 120.],
+              [150., 120., 120.])))])
+def test_derive_surface(small_grofile, n_cells, max_width, z_avg):
+    surf = derive_surface(n_cells, small_grofile, max_width)
+    for cell, calc_cell in zip(z_avg, surf):
+        assert_almost_equal(cell, calc_cell)
+
+
+@pytest.mark.parametrize('n_cells, max_width', [(3, 3)])
+@pytest.mark.parametrize('dummy_array, z_avg', [(
+    # dummy coordinates [x,y,z]
+    np.array([[0., 0., 150.],
+              [10., 0., 150.],
+              [20., 0., 150.],
+              [0., 10., 150.],
+              [10., 10., 120.],
+              [20., 10., 120.],
+              [0., 20., 120.],
+              [10., 20., 120.],
+              [20., 20., 120.]]),
+    # z_avg in grid
+    np.array(([150., 150., 120.],
+              [150., 120., 120.],
+              [150., 120., 120.]))
+)])
+def test_derive_surface_from_numpy(dummy_array, n_cells, max_width, z_avg):
+    u = mda.Universe(dummy_array, n_atoms=len(dummy_array))
+    selection = u.select_atoms('index 0:9')
+    surf = derive_surface(n_cells, selection, max_width)
+    for cell, calc_cell in zip(z_avg, surf):
+        assert_almost_equal(cell, calc_cell)
+
+
+@pytest.mark.parametrize('n_cells, max_width', [(3, 3)])
+@pytest.mark.parametrize('dummy_array, z_avg', [(
+    # dummy coordinates [x,y,z]
+    np.array([[0., 0., 150.],
+              [0., 0., 150.],
+              [20., 0., 150.],
+              [0., 0., 150.],
+              [10., 10., 150.],
+              [20., 10., 150.],
+              [0., 20., 150.],
+              [10., 20., 150.],
+              [20., 20., 150.]]),
+    # z_avg in grid
+    np.array(([150., np.nan, 150.],
+              [np.nan, 150., 150.],
+              [150., 150., 150.]))
+)])
+def test_derive_surface_from_numpy_with_nans(dummy_array, n_cells, max_width, z_avg):
+    u = mda.Universe(dummy_array, n_atoms=len(dummy_array))
+    selection = u.select_atoms('index 0:9')
+    surf = derive_surface(n_cells, selection, max_width)
+    for cell, calc_cell in zip(z_avg, surf):
+        assert_almost_equal(cell, calc_cell)

--- a/membrane_curvature/tests/test_mdakit_membcurv.py
+++ b/membrane_curvature/tests/test_mdakit_membcurv.py
@@ -151,19 +151,17 @@ def test_mean_curvature_all():
         assert_almost_equal(h, h_test)
 
 
-@pytest.mark.parametrize('n_cells, grid_z_coords, unit', [(
+@pytest.mark.parametrize('n_cells, grid_z_coords', [(
     # number of cells
     3,
     # z position in grid
     np.array([[10., 10., 10.],
               [10., 10., 10.],
-              [10., 10., 10.]]),
-    # number of beads per grid
-    [[1., 1., 1.],
-     [1., 1., 1.],
-     [1., 1., 1.]])])
-def test_avg_unit_cell_identity(n_cells, grid_z_coords, unit):
+              [10., 10., 10.]])
+)])
+def test_avg_unit_cell_identity(n_cells, grid_z_coords):
     z_ref = np.zeros([n_cells, n_cells])
+    # number of beads per grid
     unit = np.ones([n_cells, n_cells])
     unit_cell = avg_unit_cell(z_ref, grid_z_coords, unit)
     for z_position, cell in zip(unit_cell, range(n_cells)):
@@ -211,7 +209,8 @@ def test_avg_unit_cell_more_beads(n_cells, grid_z_coords, grid_norm, grid_avg):
 
 @pytest.mark.parametrize('n_cells, max_width, z_avg', [(
     # number of cells
-    3, 3,
+    # max_width is 3nm/30A (from GRO_PO4_SMALL)
+    3, 30,
     # z ref of surface
     # z coordinate in grid
     np.array(([150., 150., 120.],
@@ -223,18 +222,18 @@ def test_derive_surface(small_grofile, n_cells, max_width, z_avg):
         assert_almost_equal(cell, calc_cell)
 
 
-@pytest.mark.parametrize('n_cells, max_width', [(3, 3)])
+@pytest.mark.parametrize('n_cells, max_width', [(3, 300)])
 @pytest.mark.parametrize('dummy_array, z_avg', [(
     # dummy coordinates [x,y,z]
     np.array([[0., 0., 150.],
-              [10., 0., 150.],
-              [20., 0., 150.],
-              [0., 10., 150.],
-              [10., 10., 120.],
-              [20., 10., 120.],
-              [0., 20., 120.],
-              [10., 20., 120.],
-              [20., 20., 120.]]),
+              [100., 0., 150.],
+              [200., 0., 150.],
+              [0., 100., 150.],
+              [100., 100., 120.],
+              [200., 100., 120.],
+              [0., 200., 120.],
+              [100., 200., 120.],
+              [200., 200., 120.]]),
     # z_avg in grid
     np.array(([150., 150., 120.],
               [150., 120., 120.],
@@ -248,18 +247,18 @@ def test_derive_surface_from_numpy(dummy_array, n_cells, max_width, z_avg):
         assert_almost_equal(cell, calc_cell)
 
 
-@pytest.mark.parametrize('n_cells, max_width', [(3, 3)])
+@pytest.mark.parametrize('n_cells, max_width', [(3, 300)])
 @pytest.mark.parametrize('dummy_array, z_avg', [(
     # dummy coordinates [x,y,z]
     np.array([[0., 0., 150.],
               [0., 0., 150.],
-              [20., 0., 150.],
+              [200., 0., 150.],
               [0., 0., 150.],
-              [10., 10., 150.],
-              [20., 10., 150.],
-              [0., 20., 150.],
-              [10., 20., 150.],
-              [20., 20., 150.]]),
+              [100., 100., 150.],
+              [200., 100., 150.],
+              [0., 200., 150.],
+              [100., 200., 150.],
+              [200., 200., 150.]]),
     # z_avg in grid
     np.array(([150., np.nan, 150.],
               [np.nan, 150., 150.],

--- a/membrane_curvature/tests/test_mdakit_membcurv.py
+++ b/membrane_curvature/tests/test_mdakit_membcurv.py
@@ -275,7 +275,7 @@ def test_avg_unit_cell_identity_other_values(n_cells, grid_z_coords):
 @pytest.mark.parametrize('n_cells, grid_z_coords, grid_norm, grid_avg', [(
     # number of cells
     3,
-    # z coordinate in grid
+    # sum of z coordinate in grid
     np.array([[10., 10., 10.],
               [10., 10., 10.],
               [10., 10., 10.]]),

--- a/membrane_curvature/tests/test_mdakit_membcurv.py
+++ b/membrane_curvature/tests/test_mdakit_membcurv.py
@@ -210,7 +210,7 @@ def test_avg_unit_cell_more_beads(n_cells, grid_z_coords, grid_norm, grid_avg):
 @pytest.mark.parametrize('n_cells, max_width, z_avg', [(
     # number of cells
     # max_width is 3nm/30A (from GRO_PO4_SMALL)
-    3, 30,
+    3, 30.,
     # z ref of surface
     # z coordinate in grid
     np.array(([150., 150., 120.],
@@ -222,7 +222,7 @@ def test_derive_surface(small_grofile, n_cells, max_width, z_avg):
         assert_almost_equal(cell, calc_cell)
 
 
-@pytest.mark.parametrize('n_cells, max_width', [(3, 300)])
+@pytest.mark.parametrize('n_cells, max_width', [(3, 300.)])
 @pytest.mark.parametrize('dummy_array, z_avg', [(
     # dummy coordinates [x,y,z]
     np.array([[0., 0., 150.],
@@ -247,7 +247,7 @@ def test_derive_surface_from_numpy(dummy_array, n_cells, max_width, z_avg):
         assert_almost_equal(cell, calc_cell)
 
 
-@pytest.mark.parametrize('n_cells, max_width', [(3, 300)])
+@pytest.mark.parametrize('n_cells, max_width', [(3, 300.)])
 @pytest.mark.parametrize('dummy_array, z_avg', [(
     # dummy coordinates [x,y,z]
     np.array([[0., 0., 150.],

--- a/membrane_curvature/tests/test_mdakit_membcurv.py
+++ b/membrane_curvature/tests/test_mdakit_membcurv.py
@@ -183,13 +183,11 @@ def test_derive_surface_from_numpy():
     dummy_array = np.array([[0., 0., 150.], [100., 0., 150.], [200., 0., 150.],
                             [0., 100., 150.], [100., 100., 120.], [200., 100., 120.],
                             [0., 200., 120.], [100., 200., 120.], [200., 200., 120.]])
-    n_cells, max_width = 3, 300
-    u = mda.Universe(dummy_array, n_atoms=len(dummy_array))
-    selection = u.select_atoms('index 0:9')
-    max_width_x = max_width_y = max_width
+    x_bin = y_bin = 3
+    x_range = y_range = (0, 300)
     expected_surface = np.array(([150., 150., 120.], [150., 120., 120.], [150., 120., 120.]))
-    average_surface = derive_surface(n_cells, n_cells, selection, max_width_x, max_width_y)
-    assert_almost_equal(average_surface, expected_surface)
+    surface = get_z_surface(dummy_array, x_bin, y_bin, x_range, y_range)
+    assert_almost_equal(surface, expected_surface)
 
 
 @pytest.mark.parametrize('x_bin, y_bin, x_range, y_range, expected_surface', [

--- a/membrane_curvature/tests/test_mdakit_membcurv.py
+++ b/membrane_curvature/tests/test_mdakit_membcurv.py
@@ -248,7 +248,7 @@ def test_get_positions(dummy_coordinates):
     [[1., 1., 1.],
      [1., 1., 1.],
      [1., 1., 1.]])])
-def test_derive_avg_unit_cell(n_cells, grid_z_coords, unit):
+def test_avg_unit_cell_identity(n_cells, grid_z_coords, unit):
     z_ref = np.zeros([n_cells, n_cells])
     unit = np.ones([n_cells, n_cells])
     unit_cell = avg_unit_cell(z_ref, n_cells, grid_z_coords, unit)
@@ -264,7 +264,7 @@ def test_derive_avg_unit_cell(n_cells, grid_z_coords, unit):
               [10., 20., 30.],
               [10., 20., 30.]]
              ))])
-def test_derive_avg_unit_cell_identity(n_cells, grid_z_coords):
+def test_avg_unit_cell_identity_other_values(n_cells, grid_z_coords):
     z_ref = np.zeros([n_cells, n_cells])
     unit = np.ones([n_cells, n_cells])
     z_avg = avg_unit_cell(z_ref, n_cells, grid_z_coords, unit)
@@ -288,8 +288,26 @@ def test_derive_avg_unit_cell_identity(n_cells, grid_z_coords):
               [10., 5., 10.],
               [10., 10., 5.]]),
 )])
-def test_derive_avg_unit_cell(n_cells, grid_z_coords, grid_norm, grid_avg):
+def test_avg_unit_cell_more_beads(n_cells, grid_z_coords, grid_norm, grid_avg):
     z_ref = np.zeros([n_cells, n_cells])
     unit_cell = avg_unit_cell(z_ref, n_cells, grid_z_coords, grid_norm)
     for cell in range(n_cells):
         assert_almost_equal(unit_cell[cell], grid_avg[cell])
+
+
+@pytest.mark.parametrize('n_cells, max_width, dummy_beads, z_avg', [(
+    # number of cells
+    3, 3,
+    # dummy coordinates (x, y, z)
+    ((0, 0, 10), (1, 0, 10), (2, 0, 10),
+     (0, 1, 10), (1, 1, 10), (2, 1, 10),
+     (0, 2, 10), (1, 2, 10), (2, 2, 10)),
+    # z ref of surface
+    # z coordinate in grid
+    np.array([[10., 10., 10.],
+              [10., 10., 10.],
+              [10., 10., 10.]]))])
+def test_derive_surface(n_cells, max_width, dummy_beads, z_avg):
+    surf = derive_surface(n_cells, dummy_beads, max_width)
+    for cell in range(n_cells):
+        assert_almost_equal( z_avg[cell], z_avg[cell] )


### PR DESCRIPTION
Function `core_fast_leaflets` split into three functions:

- [x] get positions for each atom in the atom group for each frame.
- [x]  identify the grid cell for each coordinate.
- [x] calculate the average z for the atom group.

Tests added:
- [x] `test_get_positions` using dummy coordinates for beads 0 to 8, all of them with `z=10`:
```
o ______ o _____ o _______ |
|   (6)  |  (7)   |   (8)  |
o ______ o _____ o _______ |
|   (3)  |  (4)   |   (5)  |
o _______o ______ o ______ |
|   (0)  |  (1)   |   (2)  |
o ______ o ______ o ______ |
```
Using the same number of beads in grids, 

- [x] `test_avg_unit_cell` added for two systems.
1.  z values of `z=10`
2. z values as below:
```
o ______ o _____ o _______ |
| (z=10) | (z=20) | (z=30) |
o ______ o _____ o _______ |
| (z=10) | (z=20) | (z=30) |
o _______o ______ o ______ |
| (z=10) | (z=20) | (z=30) |
o ______ o ______ o ______ |
```
3. z values of `z=10` and number of beads per unit cell as shown below:
```
o ____ o ____ o ___ |
|   2  |  1   |  1  |
o ____ o ____ o ___ |
|   1  |  2   |  1  |
o ____ o ____ o ___ |
|   1  |  1   |  2  |
o ____ o ____ o ___ |
```

- [x] `test_derive_surface` added for same `dummy_coordinates` as in `test_get_positions`.