### PR TITLE
Trigger explicit warning when out of boundaries only once 

### DIFF
--- a/docs/api/surface.rst
+++ b/docs/api/surface.rst
@@ -1,3 +1,4 @@
 
 .. automodule:: membrane_curvature.surface
     :members:
+    :exclude-members: WarnOnce

--- a/membrane_curvature/tests/test_membrane_curvature.py
+++ b/membrane_curvature/tests/test_membrane_curvature.py
@@ -585,7 +585,7 @@ class TestMembraneCurvature(object):
     def test_positive_coordinates_exceed_grid(self, x_bin, y_bin, box_dim, dummy_array):
         u = mda.Universe(dummy_array, n_atoms=len(dummy_array))
         u.dimensions = [box_dim, box_dim, 300, 90., 90., 90.]
-        regex = (r"Atom coordinates exceed size of grid")
+        regex = (r"exceed boundaries | size of grid")
         with pytest.warns(UserWarning, match=regex):
             MembraneCurvature(u, select='all',
                               n_x_bins=x_bin,
@@ -607,7 +607,7 @@ class TestMembraneCurvature(object):
     def test_negative_coordinates_exceed_grid(self, x_bin, y_bin, box_dim, dummy_array):
         u = mda.Universe(dummy_array, n_atoms=len(dummy_array))
         u.dimensions = [box_dim, box_dim, 300,  90., 90., 90.]
-        regex = (r"Atom with negative coordinates falls")
+        regex = (r"exceed boundaries | coordinates falls")
         with pytest.warns(UserWarning, match=regex):
             MembraneCurvature(u, select='all',
                               n_x_bins=x_bin,


### PR DESCRIPTION
## Description
As described in #86, the explicit warning messages introduced in #83 significantly affect performance. In this PR I introduced the `WarnOnce` class in `surface.py`, which provides an explicit message only once and after that triggers a generic message. It saves time when computing in membrane-protein systems, in particular. Tests were updated with regex that match both patterns.

## Status
- [x] Ready to go