### PR TITLE
Add py311 to CI and towards NEP29

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -95,6 +95,10 @@ jobs:
         pip install git+https://github.com/MDAnalysis/mdanalysis.git@develop#subdirectory=package
         python -m pip install .
 
+    - name: install pytest
+      run: |
+        pip install pytest
+
     - name: run tests
       run: |
-        pytest -v --cov=membrane_curvature --cov-report=xml --color=yes membrane_curvature/tests/
+        pytest --disable-pytest-warnings membrane_curvature/tests/

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -33,9 +33,6 @@ jobs:
             os: ubuntu-latest
             python-version: 3.7
             env_file: min
-          # - os: ubuntu-latest
-          #   python-version: '3.11.0-rc.1'
-
 
     steps:
     - uses: actions/checkout@v3
@@ -80,3 +77,23 @@ jobs:
         name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
         fail_ci_if_error: True
 
+  latest_python:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        latest-python : ["3.11.0-rc.2"]
+    
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.latest-python }}
+
+    - name:  pip install membrane-curvature
+      run: |
+        python -m pip install . 
+
+    - name: run tests
+      run: |
+        pytest -v --cov=membrane_curvature --cov-report=xml --color=yes membrane_curvature/tests/

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -26,12 +26,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
         env_file: [env, ]
         include:
           - name: minimum_requirements
             os: ubuntu-latest
-            python-version: 3.7
+            python-version: 3.8
             env_file: min
 
     steps:
@@ -77,12 +77,12 @@ jobs:
         name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
         fail_ci_if_error: True
 
-  latest_python:
+  upstream_develop:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        latest-python : ["3.11.0-rc.2"]
+        latest-python : ["3.10", "3.11"]
     
     steps:
     - uses: actions/checkout@v3
@@ -97,7 +97,7 @@ jobs:
 
     - name: install pytest
       run: |
-        pip install pytest
+        python -m pip install pytest
 
     - name: run tests
       run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -92,6 +92,7 @@ jobs:
 
     - name:  pip install membrane-curvature
       run: |
+        pip install git+https://github.com/MDAnalysis/mdanalysis.git@develop
         python -m pip install . 
 
     - name: run tests

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -31,11 +31,14 @@ jobs:
         include:
           - name: minimum_requirements
             os: ubuntu-latest
-            python-version: 3.6
+            python-version: 3.7
             env_file: min
+          # - os: ubuntu-20.04
+          #   python-version: '3.11.0-rc.1'
+
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Additional info about the build
       shell: bash

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -33,8 +33,8 @@ jobs:
             os: ubuntu-latest
             python-version: 3.7
             env_file: min
-          # - os: ubuntu-20.04
-          #   python-version: '3.11.0-rc.1'
+          - os: ubuntu-latest
+            python-version: '3.11.0-rc.1'
 
 
     steps:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -33,8 +33,8 @@ jobs:
             os: ubuntu-latest
             python-version: 3.7
             env_file: min
-          - os: ubuntu-latest
-            python-version: '3.11.0-rc.1'
+          # - os: ubuntu-latest
+          #   python-version: '3.11.0-rc.1'
 
 
     steps:
@@ -73,7 +73,7 @@ jobs:
         pytest -v --cov=membrane_curvature --cov-report=xml --color=yes membrane_curvature/tests/
 
     - name: CodeCov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         file: ./coverage.xml
         flags: unittests

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -92,8 +92,8 @@ jobs:
 
     - name:  pip install membrane-curvature
       run: |
-        pip install git+https://github.com/MDAnalysis/mdanalysis.git@develop
-        python -m pip install . 
+        pip install git+https://github.com/MDAnalysis/mdanalysis.git@develop#subdirectory=package
+        python -m pip install .
 
     - name: run tests
       run: |

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -14,4 +14,4 @@ dependencies:
 
     # Pip-only installs
   - pip:
-    - MDAnalysis==2.0.0b0
+    - MDAnalysis>=2.0.0

--- a/devtools/conda-envs/test_min.yaml
+++ b/devtools/conda-envs/test_min.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python
   - pip
-  - numpy==1.16.0
+  - numpy==1.20.0
   - sphinx
      # Testing
   - pytest

--- a/devtools/conda-envs/test_min.yaml
+++ b/devtools/conda-envs/test_min.yaml
@@ -14,4 +14,4 @@ dependencies:
 
     # Pip-only installs
   - pip:
-    - MDAnalysis==2.0.0b0
+    - MDAnalysis==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     # url='http://www.my_package.com',  # Website
     install_requires=[
         'numpy>=1.20.0',
-        'mdanalysis>=2.3.0'
+        'mdanalysis>=2.1.0'
     ],
 
     # packages required to run tests
@@ -59,7 +59,7 @@ setup(
     #            'Mac OS-X',
     #            'Unix',
     #            'Windows'],            # Valid platforms your code works on, adjust to your flavor
-    python_requires=">=3.7",          # Python version restrictions
+    python_requires=">=3.8",          # Python version restrictions
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -75,6 +75,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ]
     # Manual control if final package is compressible or not, set False to prevent the .egg from being made
     # zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     # url='http://www.my_package.com',  # Website
     install_requires=[
         'numpy>=1.20.0',
-        'mdanalysis>=2.0.0'
+        'mdanalysis>=2.2.0'
     ],
 
     # packages required to run tests

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     #            'Mac OS-X',
     #            'Unix',
     #            'Windows'],            # Valid platforms your code works on, adjust to your flavor
-    python_requires=">=3.6",          # Python version restrictions
+    python_requires=">=3.7",          # Python version restrictions
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     # url='http://www.my_package.com',  # Website
     install_requires=[
         'numpy>=1.20.0',
-        'mdanalysis>=2.4.0-dev0'
+        'mdanalysis>=2.3.0'
     ],
 
     # packages required to run tests

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     # Additional entries you may want simply uncomment the lines you want and fill in the data
     # url='http://www.my_package.com',  # Website
     install_requires=[
-        'numpy>=1.16.0',
+        'numpy>=1.20.0',
         'mdanalysis>=2.0.0b0',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     # url='http://www.my_package.com',  # Website
     install_requires=[
         'numpy>=1.20.0',
-        'mdanalysis>=2.2.0'
+        'mdanalysis>=2.3.0'
     ],
 
     # packages required to run tests

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     # url='http://www.my_package.com',  # Website
     install_requires=[
         'numpy>=1.20.0',
-        'mdanalysis>=2.1.0'
+        'mdanalysis>=2.0.0'
     ],
 
     # packages required to run tests

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     # url='http://www.my_package.com',  # Website
     install_requires=[
         'numpy>=1.20.0',
-        'mdanalysis>=2.3.0'
+        'mdanalysis>=2.0.0'
     ],
 
     # packages required to run tests
@@ -71,7 +71,6 @@ setup(
         'Topic :: Scientific/Engineering ',
         'Topic :: Scientific/Engineering :: Biophysics ',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     # url='http://www.my_package.com',  # Website
     install_requires=[
         'numpy>=1.20.0',
-        'mdanalysis>=2.0.0b0',
+        'mdanalysis>=2.4.0-dev0'
     ],
 
     # packages required to run tests


### PR DESCRIPTION
## Description
Fixes #101 

## Changes
- [x] Bumped actions version in CI.
- [x] Bumped python version in `minimum_requirements` CI.
- [x] Bumped numpy and MDA versions in `setup.py`.
- [x] Bumped `python_requires` to 3.8 in `setup.py`.
- [x] Added `upstream_develop` job in CI for Python 3.10 and 3.11.    

## Status
- [x] Ready to go