### PR TITLE
update conda env files

### DIFF
--- a/devtools/conda-envs/environment.yaml
+++ b/devtools/conda-envs/environment.yaml
@@ -1,12 +1,8 @@
 name: membrane-curvature
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python
   - pip
   - numpy
-
-    # Pip-only installs
-  - pip:
-    - MDAnalysis>=2.0.0b0
+  - MDAnalysis>=2.0.0

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,7 +1,6 @@
 name: test
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python
   - pip
@@ -11,7 +10,4 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-
-    # Pip-only installs
-  - pip:
-    - MDAnalysis>=2.0.0
+  - MDAnalysis>=2.0.0

--- a/devtools/conda-envs/test_min.yaml
+++ b/devtools/conda-envs/test_min.yaml
@@ -1,7 +1,6 @@
 name: test
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python
   - pip
@@ -11,7 +10,4 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-
-    # Pip-only installs
-  - pip:
-    - MDAnalysis==2.0.0
+  - MDAnalysis==2.0.0


### PR DESCRIPTION
## Description
The conda env files that are being used for CI appeared outdated. In this PR I am trying out if they can be simplified.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] only use conda-forge channel (removed defaults)
- [x] install MDAnalysis via conda instead of pip


## Questions
- [ ] Was there a good reason why MDAnalysis was pip installed??

## Status
- [x] Ready to go