### PR TITLE
Refact: separate derivatives from curvature calculations w/ Monge gauge helpers

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,10 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
+
+import matplotlib
+matplotlib.use("Agg")
+
 import datetime
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/pages/Algorithm.rst
+++ b/docs/source/pages/Algorithm.rst
@@ -96,6 +96,12 @@ to the chosen grid resolution.
    very coarse grids may still affect curvature estimates due to finite-difference
    discretization error.
 
+Curvature is obtained in two steps: partial derivatives of the height field on the
+grid are estimated (for example with :func:`numpy.gradient` and box spacing), then
+mapped to mean curvature :math:`H` and Gaussian curvature :math:`K` using the
+Monge-gauge formulas in :func:`~membrane_curvature.curvature.mean_curvature_monge`
+and :func:`~membrane_curvature.curvature.gaussian_curvature_monge`.
+
 For every frame of the trajectory, the surface derived from the 
 :class:`~MDAnalysis.core.groups.AtomGroup` is
 calculated and stored in :attr:`~MembraneCurvature.results.z_surface`.

--- a/membrane_curvature/__init__.py
+++ b/membrane_curvature/__init__.py
@@ -12,7 +12,12 @@ MDAkit for Membrane Curvature
 
 # Add imports here
 from .surface import normalized_grid, derive_surface, get_z_surface
-from .curvature import mean_curvature, gaussian_curvature
+from .curvature import (
+    mean_curvature,
+    gaussian_curvature,
+    mean_curvature_monge,
+    gaussian_curvature_monge,
+)
 from .base import MembraneCurvature
 
 # Handle version

--- a/membrane_curvature/curvature.py
+++ b/membrane_curvature/curvature.py
@@ -4,22 +4,35 @@ r"""
 Curvature
 --------------------
 
-In MembraneCurvature, we calculate Gaussian and mean curvature from a cloud of points.
+In MembraneCurvature, we calculate curvature from a height field :math:`z = f(x,y)`
+using the Monge gauge formulas, where partial derivatives are estimated from the
+derived surface.
 
-Gaussian curvature is defined by
+With the Monge gauge formulas, we map first derivatives :math:`(\partial_x, \partial_y)`, and second
+and mixed derivatives :math:`(\partial_{xx}, \partial_{yy}, \partial_{xy})` to the definitions of
+curvature.
+
+Mean curvature :math:`H`, defined by:
+
+.. math:: H =
+    \frac{(1+\partial_x^2)\partial_{yy}+(1+\partial_y^2)\partial_{xx}-2\partial_x\partial_y\partial_{xy}}
+    {2(1+\partial_x^2+\partial_y^2)^{3/2}},
+
+and Gaussian curvature :math:`K`, defined by:
 
 .. math:: K = \frac{\partial_{xx}\partial_{yy}-\partial_{xy}^2}
    {(1+\partial_x^2+\partial_y^2)^2}.
 
-Mean curvature is defined by
 
-.. math:: H =
-    \frac{(1+\partial_x^2)\partial_{yy}+(1+\partial_y^2)\partial_{xx}-2\partial_x\partial_y\partial_{xy}}
-    {2(1+\partial_x^2+\partial_y^2)^{3/2}}.
+The Monge gauge formulas are implemented separately in the helpers 
+:func:`mean_curvature_monge` and :func:`gaussian_curvature_monge`, which accept
+precomputed partial derivatives as arguments. This approach intends to separate the
+curvature algebra from the derivative estimation.
 
-
-Notes
----------
+To estimate partial derivatives, we use :func:`mean_curvature` and :func:`gaussian_curvature`
+from the discrete height field using :func:`numpy.gradient`, then pass them to the
+Monge gauge functions above. Optional spacing arguments (``dx``, ``dy``) are
+forwarded to :func:`numpy.gradient` for physical-unit calculations.
 
 Since the mean curvature calculates the arithmetic mean of two
 principal curvatures, the default units of :math:`H` are Å\ :sup:`-1`.
@@ -53,10 +66,77 @@ Functions
 import numpy as np
 
 
+def mean_curvature_monge(fx, fy, fxx, fyy, fxy):
+    """
+    Helper to calculate mean curvature :math:`H` from partial derivatives of :math:`z = f(x, y)`.
+
+    Same expression as in :func:`mean_curvature` once first derivatives
+    :math:`(\partial_x, \partial_y)` and second and mixed derivatives
+    :math:`(\partial_{xx}, \partial_{yy}, \partial_{xy})` of :math:`z` are known,
+    supplied as ``fx``, ``fy``, ``fxx``, ``fyy``, ``fxy`` (see the module equations
+    above). This function does not compute gradients.
+
+    Parameters
+    ----------
+    fx : np.ndarray.
+        Values of :math:`\partial_x z` on the grid.
+    fy : np.ndarray.
+        Values of :math:`\partial_y z` on the grid.
+    fxx : np.ndarray.
+        Values of :math:`\partial_{xx} z` on the grid.
+    fyy : np.ndarray.
+        Values of :math:`\partial_{yy} z` on the grid.
+    fxy : np.ndarray.
+        Values of :math:`\partial_{xy} z` on the grid.
+
+    Returns
+    -------
+    H : np.ndarray.
+        Mean curvature, same shape as the input arrays.
+
+    """
+    H = (1 + fx**2) * fyy + (1 + fy**2) * fxx - 2 * fx * fy * fxy
+    H = H / (2 * (1 + fx**2 + fy**2) ** (1.5))
+    return H
+
+
+def gaussian_curvature_monge(fx, fy, fxx, fyy, fxy):
+    """
+    Helper to calculate Gaussian curvature :math:`K` from partial derivatives of :math:`z = f(x, y)`.
+
+    Same expression as in :func:`gaussian_curvature` once first derivatives
+    :math:`(\partial_x, \partial_y)` and second and mixed derivatives
+    :math:`(\partial_{xx}, \partial_{yy}, \partial_{xy})` of :math:`z` are known,
+    supplied as ``fx``, ``fy``, ``fxx``, ``fyy``, ``fxy`` (see the module equations
+    above). This function does not compute gradients.
+
+    Parameters
+    ----------
+    fx : np.ndarray.
+        Values of :math:`\partial_x z` on the grid.
+    fy : np.ndarray.
+        Values of :math:`\partial_y z` on the grid.
+    fxx : np.ndarray.
+        Values of :math:`\partial_{xx} z` on the grid.
+    fyy : np.ndarray.
+        Values of :math:`\partial_{yy} z` on the grid.
+    fxy : np.ndarray.
+        Values of :math:`\partial_{xy} z` on the grid.
+
+    Returns
+    -------
+    K : np.ndarray.
+        Gaussian curvature, same shape as the input arrays.
+
+    """
+    return (fxx * fyy - (fxy**2)) / (1 + (fx**2) + (fy**2)) ** 2
+
+
 def gaussian_curvature(Z, *varargs):
     """
     Calculate Gaussian curvature from Z cloud points.
 
+    Uses :func:`numpy.gradient` on `Z`, then :func:`gaussian_curvature_monge`.
 
     Parameters
     ----------
@@ -78,15 +158,14 @@ def gaussian_curvature(Z, *varargs):
     Zxx, Zxy = np.gradient(Zx, *varargs)
     _, Zyy = np.gradient(Zy, *varargs)
 
-    K = (Zxx * Zyy - (Zxy**2)) / (1 + (Zx**2) + (Zy**2)) ** 2
-
-    return K
+    return gaussian_curvature_monge(Zx, Zy, Zxx, Zyy, Zxy)
 
 
 def mean_curvature(Z, *varargs):
     """
     Calculates mean curvature from Z cloud points.
 
+    Uses :func:`numpy.gradient` on `Z`, then :func:`mean_curvature_monge`.
 
     Parameters
     ----------
@@ -108,7 +187,4 @@ def mean_curvature(Z, *varargs):
     Zxx, Zxy = np.gradient(Zx, *varargs)
     _, Zyy = np.gradient(Zy, *varargs)
 
-    H = (1 + Zx**2) * Zyy + (1 + Zy**2) * Zxx - 2 * Zx * Zy * Zxy
-    H = H / (2 * (1 + Zx**2 + Zy**2) ** (1.5))
-
-    return H
+    return mean_curvature_monge(Zx, Zy, Zxx, Zyy, Zxy)

--- a/membrane_curvature/curvature.py
+++ b/membrane_curvature/curvature.py
@@ -79,15 +79,15 @@ def mean_curvature_monge(fx, fy, fxx, fyy, fxy):
     Parameters
     ----------
     fx : np.ndarray.
-        Values of :math:`\partial_x z` on the grid.
+        Values of :math:`\partial_x` on the grid.
     fy : np.ndarray.
-        Values of :math:`\partial_y z` on the grid.
+        Values of :math:`\partial_y` on the grid.
     fxx : np.ndarray.
-        Values of :math:`\partial_{xx} z` on the grid.
+        Values of :math:`\partial_{xx}` on the grid.
     fyy : np.ndarray.
-        Values of :math:`\partial_{yy} z` on the grid.
+        Values of :math:`\partial_{yy}` on the grid.
     fxy : np.ndarray.
-        Values of :math:`\partial_{xy} z` on the grid.
+        Values of :math:`\partial_{xy}` on the grid.
 
     Returns
     -------
@@ -113,15 +113,15 @@ def gaussian_curvature_monge(fx, fy, fxx, fyy, fxy):
     Parameters
     ----------
     fx : np.ndarray.
-        Values of :math:`\partial_x z` on the grid.
+        Values of :math:`\partial_x` on the grid.
     fy : np.ndarray.
-        Values of :math:`\partial_y z` on the grid.
+        Values of :math:`\partial_y` on the grid.
     fxx : np.ndarray.
-        Values of :math:`\partial_{xx} z` on the grid.
+        Values of :math:`\partial_{xx}` on the grid.
     fyy : np.ndarray.
-        Values of :math:`\partial_{yy} z` on the grid.
+        Values of :math:`\partial_{yy}` on the grid.
     fxy : np.ndarray.
-        Values of :math:`\partial_{xy} z` on the grid.
+        Values of :math:`\partial_{xy}` on the grid.
 
     Returns
     -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ docs = [
     "mdanalysis-sphinx-theme",
     "nbsphinx",
     "ipywidgets",
-    "nglview"
+    "nglview",
+    "myst-nb"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Description
Refactors curvature using Monge gauge helpers, separating derivatives from curvature calculations.
~Since there is a CI problem~ fixed in #141 , I focused on this PR in the meantime, purposely avoiding modifying or adding tests. The separation here is strategic for modularity and maintainability.

Changes in this PR include:
- Refactored mean and Gaussian curvature in `curvature.py` using Monge as helpers.
- Update docstrings and doc pages.

I was getting some issues generating the docs and:
- Added a missing dependency: `myst-nb` (note the docs folder have `.ipynb` files). 
- Modified the docs `conf.py` to get matplotlib `Agg` backend when building html with ipython. This avoids `NotImplementedError` when `plt.subplots` runs in `visualization.rst`. 