### PR TITLE
Fix CI: update min deps, drop old Python versions, extend to py314.

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,16 +24,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         env_file: [env, ]
         include:
           - name: minimum_requirements
             os: ubuntu-latest
-            python-version: 3.9
+            python-version: 3.11
             env_file: min
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Additional info about the build
       shell: bash
@@ -83,11 +83,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        latest-python : ["3.10", "3.11", "3.12"]
-    
+        latest-python: ["3.11", "3.12", "3.13", "3.14"]
+
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.latest-python }}
 

--- a/devtools/conda-envs/test_min.yaml
+++ b/devtools/conda-envs/test_min.yaml
@@ -4,8 +4,8 @@ channels:
 dependencies:
   - python
   - pip
-  - numpy==1.23.5
-  - MDAnalysis==2.4.3
+  - numpy==1.23.0
+  - MDAnalysis==2.4.0
   - sphinx
      # Testing
   - pytest

--- a/devtools/conda-envs/test_min.yaml
+++ b/devtools/conda-envs/test_min.yaml
@@ -4,8 +4,8 @@ channels:
 dependencies:
   - python
   - pip
-  - numpy==1.23.0
-  - MDAnalysis==2.4.0
+  - numpy==1.23.5
+  - MDAnalysis==2.4.3
   - sphinx
      # Testing
   - pytest

--- a/devtools/conda-envs/test_min.yaml
+++ b/devtools/conda-envs/test_min.yaml
@@ -4,8 +4,8 @@ channels:
 dependencies:
   - python
   - pip
-  - numpy==1.21.0
-  - MDAnalysis==2.0.0
+  - numpy==1.23.5
+  - MDAnalysis==2.4.3
   - sphinx
      # Testing
   - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,15 +14,15 @@ maintainers = [
     {name = "Estefania Barreto-Ojeda", email = "estefania@ojeda-e.com"},
 ]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 keywords = [
     "python", "biophysics", "molecular-dynamics",
     "molecular-simulation", "analysis",
     "trajectory-analysis",
 ]
 dependencies = [
-    'numpy>=1.21.0',
-    'mdanalysis>=2.0.0'
+    'numpy>=1.23.0',
+    'mdanalysis>=2.4.0'
 ]
 
 classifiers = [
@@ -33,12 +33,12 @@ classifiers = [
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
-        'Topic :: Scientific/Engineering ',
+        'Topic :: Scientific/Engineering',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12'
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14'
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
(cherry picked from commit b43955ee3215213d23861112441c4f38c87c70be)

## Context:
The main blocker in #136 is adding my username to TestPyPI, which is required to properly test the deployment workflow before merging. However, this is not necessary to resolve the current CI failures in [upstream-develop 3.10](https://github.com/MDAnalysis/membrane-curvature/actions/runs/24798335966/job/72573974222?pr=140#logs).

To avoid coupling unrelated concerns, I have split the work from #136 into two separate PRs:

- One focused solely on fixing the deployment workflow (#136).
- This one, focused on fixing the CI.

This separation also helps reduce pressure on resolving the deployment-related PR immediately. IMO, while the deployment can wait, fixing the CI is more time-sensitive. I chose this approach because the CI is currently failing, and merging changes alongside unrelated deployment work would make the situation unclear and I don't feel comfortable doing so.

## Description
Note that yhe changes here are cherry-picked from #136 and are limited to what is required to restore a passing CI:

- Dropping support for older Python versions and extending support up to 3.14.
- Bumping minimum dependency versions.

