### PR TITLE
Refact: Solve Fourier least-squares with truncated SVD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,10 @@ ENV/
 # There are reports this comes from LLVM profiling, but also Xcode 9.
 *profraw
 *.npz
+
+# macOS / editor files
+.DS_Store
+.vscode/
+
+# Generated docs figs
+docs/savefig/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Membranecurvature CHANGELOG
 =============================
 
+* Refactored Fourier surface method to use singular-value decomposition (SVD) instead of least-squares (PR #177)
 * Apply coordinate wrapping only for ``surface_method='binning'``, set ``wrap`` to ``None`` by default,
   raise ValueError when ``surface_method='fourier'`` (PR #170).
 * Set `'fourier'` as default surface method. (PR #168)

--- a/docs/source/pages/Algorithm.rst
+++ b/docs/source/pages/Algorithm.rst
@@ -231,8 +231,14 @@ so columns appear as ``1, cos_{(m1,n1)}, sin_{(m1,n1)}, cos_{(m2,n2)}, sin_{(m2,
 2.1.4 Solve least-squares system
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 We then solve the least-squares system for the Fourier coefficients using
-:func:`~membrane_curvature.fourier_surface._fourier_fit_from_atoms` (which
-calls :func:`numpy.linalg.lstsq`). 
+:func:`~membrane_curvature.fourier_surface._fourier_fit_from_atoms`, which
+calls :func:`~membrane_curvature.fourier_surface._solve_design_least_squares`.
+The latter function solves the linear least-squares system via truncated SVD.
+The ``rcond`` parameter follows the same singular-value cutoff convention as
+:func:`numpy.linalg.lstsq`. Please note that the implementation in MembraneCurvature
+does not call :func:`numpy.linalg.lstsq` but solves the linear least-squares system via
+truncated SVD.
+
 This function solves the least-squares system for the Fourier coefficients and splits the solution vector into the mean term and
 the per-mode amplitudes with :func:`~membrane_curvature.fourier_surface._unpack_coefficients`.
 The returned coefficients are then used to evaluate the fitted height and its
@@ -247,7 +253,8 @@ by minimizing the residual sum of squares between the observed heights and the f
    \operatorname{arg\,min}_{\boldsymbol{\theta}}
    \lVert \mathbf{\Phi}\,\boldsymbol{\theta} - \mathbf{z} \rVert_2^2
 
-via :func:`numpy.linalg.lstsq`. Because the model is linear in
+via truncated SVD (:func:`~membrane_curvature.fourier_surface._solve_design_least_squares`).
+Because the model is linear in
 :math:`\boldsymbol{\theta}`, no nonlinear optimisation is required.
 If the effective rank of :math:`\mathbf{\Phi}` is smaller than :math:`P`,
 a ``UserWarning`` is emitted.
@@ -332,10 +339,17 @@ Atoms that map outside the valid bin range
 trigger a one-time detailed warning. The function uses a WarnOnce helper so the full diagnostic
 is shown on first occurrence and a short message on subsequent occurrences.
 
+To populate the grid, :class:`~membrane_curvature.base.MembraneCurvature` wraps
+the coordinates of the :class:`~MDAnalysis.core.groups.AtomGroup` of reference
+using :meth:`~MDAnalysis.core.groups.AtomGroup.wrap` only when ``wrap=True`` is
+set (the default for ``surface_method='binning'``).
+
 Empty bins (zero samples) are represented as :data:`numpy.nan` in the returned
 ``(n_x_bins, n_y_bins)`` array: the implementation replaces zero counts
 with :data:`numpy.nan` and divides summed z-values by the per-bin counts. As a result,
 trajectory averages use :func:`numpy.nanmean` and therefore ignore empty bins.
+
+
 
 .. warning::
   

--- a/docs/source/pages/Algorithm.rst
+++ b/docs/source/pages/Algorithm.rst
@@ -232,15 +232,12 @@ so columns appear as ``1, cos_{(m1,n1)}, sin_{(m1,n1)}, cos_{(m2,n2)}, sin_{(m2,
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 We then solve the least-squares system for the Fourier coefficients using
 :func:`~membrane_curvature.fourier_surface._fourier_fit_from_atoms`, which
-calls :func:`~membrane_curvature.fourier_surface._solve_design_least_squares`.
+calls :func:`~membrane_curvature.fourier_surface._solve_design_least_squares_svd`.
 The latter function solves the linear least-squares system via truncated SVD.
-The ``rcond`` parameter follows the same singular-value cutoff convention as
-:func:`numpy.linalg.lstsq`. Please note that the implementation in MembraneCurvature
-does not call :func:`numpy.linalg.lstsq` but solves the linear least-squares system via
-truncated SVD.
 
-This function solves the least-squares system for the Fourier coefficients and splits the solution vector into the mean term and
-the per-mode amplitudes with :func:`~membrane_curvature.fourier_surface._unpack_coefficients`.
+This function solves the least-squares system for the Fourier coefficients and splits the solution
+vector into the mean term :math:`A_{00}` and the per-mode amplitudes :math:`A_{mn}` and :math:`B_{mn}`
+with :func:`~membrane_curvature.fourier_surface._unpack_coefficients`.
 The returned coefficients are then used to evaluate the fitted height and its
 analytic derivatives on the bin-centre mesh via :func:`~membrane_curvature.fourier_surface._eval_fourier_surface`.
 
@@ -253,12 +250,17 @@ by minimizing the residual sum of squares between the observed heights and the f
    \operatorname{arg\,min}_{\boldsymbol{\theta}}
    \lVert \mathbf{\Phi}\,\boldsymbol{\theta} - \mathbf{z} \rVert_2^2
 
-via truncated SVD (:func:`~membrane_curvature.fourier_surface._solve_design_least_squares`).
+via truncated SVD (:func:`~membrane_curvature.fourier_surface._solve_design_least_squares_svd`).
 Because the model is linear in
 :math:`\boldsymbol{\theta}`, no nonlinear optimisation is required.
 If the effective rank of :math:`\mathbf{\Phi}` is smaller than :math:`P`,
-a ``UserWarning`` is emitted.
+a ``UserWarning`` is emitted. The truncated-SVD solver still returns a well-defined
+minimum-norm least-squares solution, but the coefficients are not uniquely
+determined by the data.
 
+Overall, truncated SVD lets us fit the best surface even when the data can't uniquely
+determine every Fourier coefficient, and it reduces noise amplification in modes that
+are not well-determined by the data.
 
 .. _binning_method:
 
@@ -348,7 +350,6 @@ Empty bins (zero samples) are represented as :data:`numpy.nan` in the returned
 ``(n_x_bins, n_y_bins)`` array: the implementation replaces zero counts
 with :data:`numpy.nan` and divides summed z-values by the per-bin counts. As a result,
 trajectory averages use :func:`numpy.nanmean` and therefore ignore empty bins.
-
 
 
 .. warning::

--- a/docs/source/pages/Usage.rst
+++ b/docs/source/pages/Usage.rst
@@ -166,6 +166,20 @@ solution, but the coefficients are not uniquely determined by the data.
   - ``fourier_rcond=1e-12`` or ``1e-10``: more aggressive truncation; can reduce noise when the
     fit is underdetermined.
 
+.. note::
+
+  All Fourier least-squares steps (design matrix, SVD, coefficients) use
+  64-bit floating point :func:`numpy.float64`. The cutoff defined by ``fourier_rcond`` is
+  a **relative threshold**: singular values with :math:`s \le rcond \cdot s_{\max}` are dropped.
+  The meaningful scale is therefore relative to the largest singular value :math:`s_{\max}`, not
+  absolute coordinates or heights.
+
+  With ``fourier_rcond=None``, the cutoff scales with the size of the least-squares problem, typically
+  the number of atoms in the selection, or the number of fitted coefficients if that is larger.
+  Passing a value much smaller than :math:`\sim 10^{-16}`, or much smaller than that automatic
+  cutoff, usually has no visible effect. To smooth an underdetermined fit on purpose, use larger
+  values such as ``1e-12`` or ``1e-10`` (see warning above).
+
 2.1.2 Binning surface method
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/pages/Usage.rst
+++ b/docs/source/pages/Usage.rst
@@ -124,11 +124,11 @@ is equivalent to:
   Use ``wrap=True`` only with ``surface_method='binning'`` to pack atoms into the primary unit cell
   on raw trajectories.
 
-Advanced: Tuning the Fourier least-squares cutoff (``rcond``)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Advanced: Tuning the Fourier least-squares cutoff (``fourier_rcond``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The Fourier surface is fit by solving a linear least-squares system with singular-value truncation `SVD`_.
-The optional cutoff ``rcond`` controls which singular values are treated as "effectively zero" and
+The optional cutoff ``fourier_rcond`` controls which singular values are treated as "effectively zero" and
 therefore removed from the solve. Smaller values keep more directions, and potentially noisier if
 the system is underdetermined. Larger values regularize more aggressively.
 

--- a/docs/source/pages/Usage.rst
+++ b/docs/source/pages/Usage.rst
@@ -1,7 +1,8 @@
 .. _usage:
 
+======
 Usage
-=========================================================
+======
 
 This page includes a practical guide to using MembraneCurvature with the surface
 derivation method of choice (binning or Fourier).
@@ -28,7 +29,7 @@ simulation systems.
 .. _surface-methods:
 
 1. Surface derivation methods
------------------------------
+=============================
 
 :class:`~membrane_curvature.base.MembraneCurvature` uses an AtomGroup as a reference,
 user-defined via the ``select`` parameter, to derive a surface and calculate mean and
@@ -62,7 +63,7 @@ For copy-paste examples of both methods see:
 .. _examples-usage:
 
 2. Examples of how to use MembraneCurvature to derive curvature profiles
-------------------------------------------------------------------------
+========================================================================
 
 The following sections offer examples of how to use MembraneCurvature to derive curvature profiles in three types of systems:
 
@@ -73,14 +74,15 @@ The following sections offer examples of how to use MembraneCurvature to derive 
 .. _membrane-only:
 
 2.1. Membrane-only systems
-------------------------------
+--------------------------
 
 In this example, we show a basic usage of MembraneCurvature in a system that
 comprises a lipid bilayer of DPPC:CHOL using the Martini force field. Since we
 have a bilayer, we select atoms of phospholipid head groups in the upper
 leaflet only using the :attr:`~select` parameter and apply coordinate wrapping.
 
-**Fourier surface method (default)**
+2.1.1 Fourier surface method (default)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We can calculate membrane curvature using the Fourier surface method by either
 setting ``surface_method='fourier'`` with ``fourier_m=2``, ``fourier_n=2``, or
@@ -122,7 +124,50 @@ is equivalent to:
   Use ``wrap=True`` only with ``surface_method='binning'`` to pack atoms into the primary unit cell
   on raw trajectories.
 
-**Binning surface method**
+Advanced: Tuning the Fourier least-squares cutoff (``rcond``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Fourier surface is fit by solving a linear least-squares system with singular-value truncation `SVD`_.
+The optional cutoff ``rcond`` controls which singular values are treated as "effectively zero" and
+therefore removed from the solve. Smaller values keep more directions, and potentially noisier if
+the system is underdetermined. Larger values regularize more aggressively.
+
+In :class:`~membrane_curvature.base.MembraneCurvature`, pass this cutoff as ``fourier_rcond``:
+
+.. code-block:: python
+
+    curvature_upper_leaflet = MembraneCurvature(universe,
+                                                select='resid 1-225 and name PO4',
+                                                surface_method='fourier',
+                                                fourier_m=2,
+                                                fourier_n=2,
+                                                fourier_rcond=1e-12
+                                                ).run()
+
+
+Note that ``fourier_rcond`` is a *relative* singular-value cutoff: singular values
+:math:`s \le rcond \cdot s_{\max}` are treated as zero.
+If the effective rank of the design matrix is smaller than the number of fitted parameters, a
+``UserWarning`` is emitted: the solver still returns a well-defined minimum-norm least-squares
+solution, but the coefficients are not uniquely determined by the data.
+
+.. warning::
+
+  ``fourier_rcond`` controls how aggressively we ignore poorly constrained combinations of
+  Fourier coefficients. **We strongly recommend using** ``fourier_rcond`` **with its
+  default value** ``None``.
+  Larger values keep fewer singular-value directions (more stable / more
+  regularized). Smaller values keep more directions (closer fit but potentially noisier).
+
+  Rough intuition:
+
+  - ``fourier_rcond=None``: sensible default; uses NumPy's heuristic cutoff.
+  - ``fourier_rcond=0``: truncate only *exactly* zero singular values.
+  - ``fourier_rcond=1e-12`` or ``1e-10``: more aggressive truncation; can reduce noise when the
+    fit is underdetermined.
+
+2.1.2 Binning surface method
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Alternatively, set ``surface_method='binning'`` and provide the values for
 the binning grid ``n_x_bins`` and ``n_y_bins``. Note that you need to apply
@@ -305,3 +350,5 @@ Curvature tool can be found in the :ref:`visualization` page.
 .. _`MDAnalysisTests`: https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
 .. _`Gromacs`: https://www.gromacs.org/
+
+.. _`SVD`: https://en.wikipedia.org/wiki/Singular_value_decomposition

--- a/membrane_curvature/base.py
+++ b/membrane_curvature/base.py
@@ -68,8 +68,11 @@ class MembraneCurvature(AnalysisBase):
     fourier_n : int, optional
         Maximum Fourier mode index in ``y`` when ``surface_method='fourier'``.
         Default ``2``.
-    fourier_lstsq_rcond : float, optional
-        ``rcond`` passed to :func:`numpy.linalg.lstsq` when ``surface_method='fourier'``.
+    fourier_rcond : float, optional
+        Singular-value cutoff for the Fourier fit via truncated SVD
+        with :func:`~membrane_curvature.fourier_surface._solve_design_least_squares_svd`
+        when ``surface_method='fourier'``. The cutoff is interpreted as a
+        relative threshold on singular values.
 
     Attributes
     ----------
@@ -212,7 +215,7 @@ class MembraneCurvature(AnalysisBase):
         surface_method='fourier',
         fourier_m=2,
         fourier_n=2,
-        fourier_lstsq_rcond=None,
+        fourier_rcond=None,
         **kwargs,
     ):
 
@@ -243,7 +246,7 @@ class MembraneCurvature(AnalysisBase):
             self.wrap = True if wrap is None else wrap
         self.fourier_m = int(fourier_m)
         self.fourier_n = int(fourier_n)
-        self.fourier_lstsq_rcond = fourier_lstsq_rcond
+        self.fourier_rcond = fourier_rcond
         if self.surface_method == 'fourier':
             if self.fourier_m < 0 or self.fourier_n < 0:
                 raise ValueError('fourier_m and fourier_n must be non-negative')
@@ -320,7 +323,7 @@ class MembraneCurvature(AnalysisBase):
                 self.n_y_bins,
                 self.fourier_m,
                 self.fourier_n,
-                rcond=self.fourier_lstsq_rcond,
+                rcond=self.fourier_rcond,
             )
             self.results.z_surface[self._frame_index] = z_f
             self.results.mean[self._frame_index] = mean_f

--- a/membrane_curvature/curvature.py
+++ b/membrane_curvature/curvature.py
@@ -169,7 +169,8 @@ def fourier_curvature(
         Maximum Fourier mode indices; see
         :func:`~membrane_curvature.fourier_surface.fourier_mode_list`.
     rcond : float or None, optional
-        Passed to :func:`numpy.linalg.lstsq`.
+        Passed to singular-value truncation for the Fourier fit.
+        See :func:`~membrane_curvature.fourier_surface._solve_design_least_squares_svd`.
 
     Returns
     -------

--- a/membrane_curvature/fourier_surface.py
+++ b/membrane_curvature/fourier_surface.py
@@ -25,6 +25,7 @@ a truncated 2D Fourier series. The workflow includes six steps:
     - :func:`_build_fourier_matrix`
 4. Solve the least-squares problem for the Fourier coefficients
     - :func:`_fourier_fit_from_atoms`
+    - :func:`_solve_design_least_squares_svd`
     - :func:`_unpack_coefficients`
 5. Reconstruct the continuous surface on a grid:
     - :func:`_bin_centre_mesh`
@@ -314,6 +315,69 @@ def _build_fourier_matrix(
     return design_matrix
 
 
+def _solve_design_least_squares_svd(
+    design_matrix: np.ndarray,
+    targets: np.ndarray,
+    rcond: float | None = None,
+) -> tuple[np.ndarray, int, np.ndarray]:
+    r"""
+    Least-squares solution with :func:`numpy.linalg.svd` and singular-value truncation.
+
+    Solves ``min ||design_matrix @ theta - targets||_2`` with a relative singular-value
+    cutoff ``rcond`` (values :math:`s \le rcond \cdot s_{\max}` are treated as
+    zero). When the system is rank-deficient, returns the minimum Euclidean-norm
+    coefficient vector among least-squares minimizers.
+
+    Parameters
+    ----------
+    design_matrix : ndarray, shape (n_rows, n_columns)
+        Design matrix with rows corresponding to atom positions and columns
+        corresponding to the basis functions.
+    targets : ndarray, shape (n_rows,)
+        Target heights.
+    rcond : float or None, optional
+        Relative cutoff for small singular values. ``None`` uses a heuristic
+        cutoff based on machine precision and the problem size.
+
+    Returns
+    -------
+    theta : ndarray, shape (n_columns,)
+        Fitted coefficients.
+    rank : int
+        Effective rank after truncation.
+    singular_values : ndarray
+        Singular values of ``design_matrix``.
+
+    .. note::
+
+        Here rank is the number of singular values greater than the cutoff.
+        The number of columns in the design matrix is the number of parameters.
+    """
+    design_matrix = np.asarray(design_matrix, dtype=np.float64)
+    targets = np.asarray(targets, dtype=np.float64)
+    n_rows, n_columns = design_matrix.shape
+    if targets.shape != (n_rows,):
+        raise ValueError('targets must have shape (design_matrix.shape[0],)')
+
+    if rcond is None:
+        rcond = np.finfo(np.float64).eps * max(n_rows, n_columns)
+
+    unitary_array, singular_values, vh = np.linalg.svd(design_matrix, full_matrices=False)
+
+    if singular_values.size == 0:
+        return np.zeros(n_columns, dtype=np.float64), 0, singular_values
+
+    cutoff = rcond * singular_values[0]
+    keep = singular_values > cutoff
+    rank = int(np.count_nonzero(keep))
+    if rank == 0:
+        return np.zeros(n_columns, dtype=np.float64), 0, singular_values
+
+    coefficients_on_span = (unitary_array[:, keep].T @ targets) / singular_values[keep]
+    theta = vh[keep].T @ coefficients_on_span
+    return theta, rank, singular_values
+
+
 # Step 4: least squares for Fourier coefficients
 def _unpack_coefficients(
     theta: np.ndarray, modes: list[tuple[int, int]]
@@ -321,7 +385,7 @@ def _unpack_coefficients(
     """
     Split the least-squares coefficient vector into the mean and per-mode amplitudes.
 
-    Used after step 4 (:func:`numpy.linalg.lstsq` in :func:`_fourier_fit_from_atoms`).
+    Used after step 4 (:func:`_solve_design_least_squares_svd` in :func:`_fourier_fit_from_atoms`).
     Index ``0`` is :math:`A_{00}`; remaining entries are cosine/sine pairs in ``modes`` order.
 
     Parameters
@@ -369,7 +433,7 @@ def _fourier_fit_from_atoms(
     M, N : int
         Maximum Fourier mode indices (see :func:`fourier_mode_list`).
     rcond : float or None, optional
-        Passed to :func:`numpy.linalg.lstsq`.
+        Relative cutoff for small singular values in :func:`_solve_design_least_squares_svd`.
 
     Returns
     -------
@@ -412,15 +476,13 @@ def _fourier_fit_from_atoms(
     y_rel = np.mod(positions[:, 1] - y0, Ly)
     z_at = positions[:, 2]
 
-    design = _build_fourier_matrix(x_rel, y_rel, Lx, Ly, modes)
-    # TODO: Consider using SVD instead since it has no problem dealing with rank deficiency.
-    # Check issue #161
-    theta, _residuals, rank, _singular_values = np.linalg.lstsq(design, z_at, rcond=rcond)
-    n_columns = int(design.shape[1])
+    design_matrix = _build_fourier_matrix(x_rel, y_rel, Lx, Ly, modes)
+    theta, rank, _singular_values = _solve_design_least_squares_svd(design_matrix, z_at, rcond=rcond)
+    n_columns = int(design_matrix.shape[1])
     if rank < n_columns:
         warnings.warn(
             'Fourier least-squares system is rank-deficient or underdetermined: '
-            f'lstsq rank is {rank} for {n_columns} parameters and {n_atom} atoms '
+            f'effective SVD rank is {rank} for {n_columns} parameters and {n_atom} atoms '
             f'(M={M}, N={N}). Coefficients may be non-unique or ill-conditioned.',
             UserWarning,
             stacklevel=2,
@@ -554,9 +616,7 @@ def _eval_fourier_surface(
     -----
     The ``derivatives=False`` branch returns ``(Z,)`` — a 1-tuple, not a bare
     ``ndarray`` — to keep a single return type (``tuple[ndarray, ...]``)
-    regardless of the flag. Callers therefore unwrap with ``[0]``. This is an
-    intentional ergonomic compromise; see the in-body TODO for the candidate
-    refactors.
+    regardless of the flag. Callers therefore unwrap with ``[0]``.
     """
     # TODO: the 1-tuple return when derivatives=False is awkward (callers do
     # [0] to unwrap). Future refactor options, in preference order:
@@ -567,9 +627,6 @@ def _eval_fourier_surface(
     #       e.g. _eval_fourier_height and _eval_fourier_height_with_derivatives;
     #   (c) return a NamedTuple/dataclass for field-name access (Z, fx, fy,
     #       fxx, fyy, fxy) while still supporting tuple unpacking.
-    # A plain dict was considered and rejected: it loses unpacking ergonomics
-    # and gives string-key typos at runtime in exchange for marginal call-site
-    # readability.
     twopi = 2.0 * np.pi
     X_rel = np.asarray(X_rel, dtype=np.float64)
     Y_rel = np.asarray(Y_rel, dtype=np.float64)
@@ -684,7 +741,8 @@ def fourier_height_from_atoms(
     M, N : int
         Maximum Fourier mode indices; see :func:`fourier_mode_list`.
     rcond : float or None, optional
-        Passed to :func:`numpy.linalg.lstsq`.
+        Relative cutoff for small singular values in
+        :func:`_solve_design_least_squares_svd`.
 
     Returns
     -------
@@ -749,7 +807,8 @@ def fourier_height_derivatives_from_atoms(
     M, N : int
         Maximum Fourier mode indices; see :func:`fourier_mode_list`.
     rcond : float or None, optional
-        Passed to :func:`numpy.linalg.lstsq`.
+        Relative cutoff for small singular values in
+        :func:`_solve_design_least_squares_svd`.
 
     Returns
     -------

--- a/membrane_curvature/tests/test_fourier_surface.py
+++ b/membrane_curvature/tests/test_fourier_surface.py
@@ -103,6 +103,31 @@ def dummy_two_mode_fourier_system(dummy_fourier_universe):
     return design_matrix, z_values
 
 
+@pytest.fixture()
+def full_rank_design_system():
+    """Full-rank design with a known exact least-squares solution."""
+    design_matrix = np.array(
+        [
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [1.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    theta_true = np.array([2.0, 3.0], dtype=np.float64)
+    targets = design_matrix @ theta_true
+    return design_matrix, targets, theta_true
+
+
+@pytest.fixture()
+def rank_deficient_design_system():
+    """Duplicate columns -> rank 1; minimum-norm solution splits mean(targets) equally."""
+    design_matrix = np.ones((3, 2), dtype=np.float64)
+    targets = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    expected_theta = np.full(2, targets.mean() / 2.0)
+    return design_matrix, targets, expected_theta
+
+
 def test_calculate_a00_2x2_grid(dummy_fourier_universe, dummy_fourier_fit):
     """Test A_00 matches np.mean of z coords"""
     expected_A00 = 9  # equivalent to np.mean(positions[:, 2])
@@ -280,32 +305,92 @@ def test_harmonic_height_and_phi_derivatives(dummy_fourier_universe, A, B):
     assert_almost_equal(h_phiphi, expected_h_phiphi)
 
 
-def test_solve_design_least_squares_theta_matches_lstsq(dummy_two_mode_fourier_system):
-    design_matrix, z_values = dummy_two_mode_fourier_system
-    theta_svd, _, _ = _solve_design_least_squares_svd(design_matrix, z_values)
-    theta_lstsq, _, _, _ = np.linalg.lstsq(design_matrix, z_values, rcond=None)
-    assert_almost_equal(theta_svd, theta_lstsq)
+def test_solve_design_least_squares_svd_targets_shape_mismatch(full_rank_design_system):
+    design_matrix, targets, _ = full_rank_design_system
+    with pytest.raises(ValueError, match='targets must have shape \\(design_matrix.shape\\[0\\],\\)'):
+        _solve_design_least_squares_svd(design_matrix, targets[:2])
 
 
-def test_solve_design_least_squares_rank_deficient_minimum_norm_solution():
-    design_matrix = np.array(
-        [
-            [1.0, 1.0],
-            [1.0, 1.0],
-            [1.0, 1.0],
-        ],
-        dtype=np.float64,
+def test_solve_design_least_squares_svd_empty_design_matrix_returns_zeros():
+    design_matrix = np.zeros((0, 3), dtype=np.float64)
+    targets = np.zeros(0, dtype=np.float64)
+    theta, rank, singular_values = _solve_design_least_squares_svd(design_matrix, targets)
+    assert rank == 0
+    assert singular_values.size == 0
+    assert_almost_equal(theta, np.zeros(3))
+
+
+def test_solve_design_least_squares_svd_recovers_known_theta(full_rank_design_system):
+    design_matrix, targets, theta_true = full_rank_design_system
+    theta, rank, _ = _solve_design_least_squares_svd(design_matrix, targets)
+    assert rank == design_matrix.shape[1]
+    assert_almost_equal(theta, theta_true)
+
+
+def test_solve_design_least_squares_svd_exact_fit_zero_residual(full_rank_design_system):
+    design_matrix, targets, theta_true = full_rank_design_system
+    theta, _, _ = _solve_design_least_squares_svd(design_matrix, targets)
+    residual = design_matrix @ theta - targets
+    assert_almost_equal(residual, np.zeros_like(targets))
+    assert_almost_equal(theta, theta_true)
+
+
+def test_solve_design_least_squares_svd_singular_values_match_numpy(full_rank_design_system):
+    design_matrix, targets, _ = full_rank_design_system
+    _, _, singular_values = _solve_design_least_squares_svd(design_matrix, targets)
+    _, expected_singular_values, _ = np.linalg.svd(design_matrix, full_matrices=False)
+    assert_almost_equal(singular_values, expected_singular_values)
+
+
+def test_solve_design_least_squares_svd_rank_matches_truncation_mask(full_rank_design_system):
+    design_matrix, targets, _ = full_rank_design_system
+    rcond = 1e-12
+    _, rank, singular_values = _solve_design_least_squares_svd(
+        design_matrix,
+        targets,
+        rcond=rcond,
     )
-    targets = np.array([1.0, 2.0, 3.0], dtype=np.float64)
-    expected_sum = float(np.mean(targets))
+    cutoff = rcond * singular_values[0]
+    expected_rank = int(np.count_nonzero(singular_values > cutoff))
+    assert rank == expected_rank
 
-    theta, rank, _singular_values = _solve_design_least_squares_svd(design_matrix, targets, rcond=None)
+
+def test_solve_design_least_squares_svd_coerces_inputs_to_float64(full_rank_design_system):
+    design_matrix, targets, theta_true = full_rank_design_system
+    design_int = design_matrix.astype(np.int64)
+    targets_int = targets.astype(np.int64)
+    theta, rank, singular_values = _solve_design_least_squares_svd(design_int, targets_int)
+    assert theta.dtype == np.float64
+    assert singular_values.dtype == np.float64
+    assert rank == design_matrix.shape[1]
+    assert_almost_equal(theta, theta_true)
+
+
+def test_solve_design_least_squares_svd_rank_deficient_minimum_norm(rank_deficient_design_system):
+    design_matrix, targets, expected_theta = rank_deficient_design_system
+    theta, rank, _ = _solve_design_least_squares_svd(design_matrix, targets, rcond=None)
     assert rank == 1
-    assert_almost_equal(theta[0] + theta[1], expected_sum)
+    assert rank < design_matrix.shape[1]
+    assert_almost_equal(theta, expected_theta)
 
-    # Minimum-norm solution has no component along the nullspace direction [1, -1].
-    assert_almost_equal(theta[0], theta[1])
-    assert_almost_equal(float(np.dot(np.array([1.0, -1.0], dtype=np.float64), theta)), 0.0)
+
+def test_solve_design_least_squares_svd_large_rcond_returns_zero_coefficients(rank_deficient_design_system):
+    design_matrix, targets, _ = rank_deficient_design_system
+    theta, rank, singular_values = _solve_design_least_squares_svd(
+        design_matrix,
+        targets,
+        rcond=1.0,
+    )
+    assert rank == 0
+    assert_almost_equal(theta, np.zeros(design_matrix.shape[1]))
+    assert singular_values.size > 0
+
+
+def test_solve_design_least_squares_svd_matches_lstsq_reference(dummy_two_mode_fourier_system):
+    design_matrix, targets = dummy_two_mode_fourier_system
+    theta_svd, _, _ = _solve_design_least_squares_svd(design_matrix, targets, rcond=None)
+    theta_lstsq, _, _, _ = np.linalg.lstsq(design_matrix, targets, rcond=None)
+    assert_almost_equal(theta_svd, theta_lstsq)
 
 
 def test_fourier_warning_rank_deficient(dummy_fourier_universe):

--- a/membrane_curvature/tests/test_fourier_surface.py
+++ b/membrane_curvature/tests/test_fourier_surface.py
@@ -16,6 +16,7 @@ from membrane_curvature.fourier_surface import (
     _harmonic_height_and_phi_derivatives,
     _eval_fourier_surface,
     _fourier_fit_from_atoms,
+    _solve_design_least_squares_svd,
     n_fourier_parameters,
     fourier_mode_list,
     fourier_height_from_atoms,
@@ -83,6 +84,23 @@ def eval_fourier_surface_common_inputs(dummy_fourier_universe):
         Lx=2.0,
         Ly=2.0,
     )
+
+
+@pytest.fixture()
+def dummy_two_mode_fourier_system(dummy_fourier_universe):
+    positions = dummy_fourier_universe.atoms.positions
+    x_positions = positions[:, 0]
+    y_positions = positions[:, 1]
+    z_values = positions[:, 2]
+    modes = [(1, 0), (0, 1)]
+    design_matrix = _build_fourier_matrix(
+        x_positions,
+        y_positions,
+        2.0,
+        2.0,
+        modes,
+    )
+    return design_matrix, z_values
 
 
 def test_calculate_a00_2x2_grid(dummy_fourier_universe, dummy_fourier_fit):
@@ -260,6 +278,34 @@ def test_harmonic_height_and_phi_derivatives(dummy_fourier_universe, A, B):
     assert_almost_equal(h, expected_h)
     assert_almost_equal(h_phi, expected_h_phi)
     assert_almost_equal(h_phiphi, expected_h_phiphi)
+
+
+def test_solve_design_least_squares_theta_matches_lstsq(dummy_two_mode_fourier_system):
+    design_matrix, z_values = dummy_two_mode_fourier_system
+    theta_svd, _, _ = _solve_design_least_squares_svd(design_matrix, z_values)
+    theta_lstsq, _, _, _ = np.linalg.lstsq(design_matrix, z_values, rcond=None)
+    assert_almost_equal(theta_svd, theta_lstsq)
+
+
+def test_solve_design_least_squares_rank_deficient_minimum_norm_solution():
+    design_matrix = np.array(
+        [
+            [1.0, 1.0],
+            [1.0, 1.0],
+            [1.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    targets = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    expected_sum = float(np.mean(targets))
+
+    theta, rank, _singular_values = _solve_design_least_squares_svd(design_matrix, targets, rcond=None)
+    assert rank == 1
+    assert_almost_equal(theta[0] + theta[1], expected_sum)
+
+    # Minimum-norm solution has no component along the nullspace direction [1, -1].
+    assert_almost_equal(theta[0], theta[1])
+    assert_almost_equal(float(np.dot(np.array([1.0, -1.0], dtype=np.float64), theta)), 0.0)
 
 
 def test_fourier_warning_rank_deficient(dummy_fourier_universe):


### PR DESCRIPTION
<!--
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #161 

## Description
<!--
Provide a brief description of the PR's purpose here.
-->

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use a bullet list. -->
- Added `_solve_design_least_squares_svd` for Fourier fits.
- Added `fourier_rcond` cutoff parameter in base (Replaced `fourier_lstsq_rcond` <-> `fourier_rcond`)
- Updated Algorithm doc page to include SVD implementation.
- Updated Usage page to include advanced example w/ `fourier_rcond` param.

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `CHANGELOG` file updated?
