### PR TITLE
CI: Replace action versions w/ commit SHA + dependabot cfg file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "18:00"
+    groups:
+      all-actions:
+        patterns: [ "*" ]
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "18:00"
+    groups:
+      production:
+        patterns: ["*"]
+        dependency-type: "production"
+      development:
+        patterns: ["*"]
+        dependency-type: "development"
+      ignore:
+      - dependency-name: "nglview"
+
+  - package-ecosystem: "conda"
+    directory: "/devtools/conda-envs"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "18:00"
+    groups:
+      all-conda:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
       development:
         patterns: ["*"]
         dependency-type: "development"
-      ignore:
+    ignore:
       - dependency-name: "nglview"
 
   - package-ecosystem: "conda"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "18:00"
+    cooldown:
+      default-days: 7
     groups:
       all-actions:
         patterns: [ "*" ]

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.11"
     - name: Install pre-commit
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.11"
     - name: Install ruff
@@ -48,7 +48,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        - uses: actions/setup-python@v6
+        - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
           with:
             python-version: "3.11"
         - name: Install package (deps for import resolution)
@@ -141,7 +141,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.latest-python }}
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Run pre-commit hooks
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: actions/setup-python@v6
       with:
         python-version: "3.11"
@@ -34,7 +34,7 @@ jobs:
     name: Lint with Ruff
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: actions/setup-python@v6
       with:
         python-version: "3.11"
@@ -47,7 +47,7 @@ jobs:
         name: Type check with ty
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v6
+        - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         - uses: actions/setup-python@v6
           with:
             python-version: "3.11"
@@ -62,7 +62,7 @@ jobs:
     name: Validate uv environment
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Install uv and set Python 3.11
       # SHA value equivalent to v8.1.0 - see github.com/astral-sh/setup-uv#usage
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
@@ -89,7 +89,7 @@ jobs:
             env_file: min
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Additional info about the build
       shell: bash
@@ -140,7 +140,7 @@ jobs:
         latest-python: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.latest-python }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -64,8 +64,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Install uv and set Python 3.11
-      # SHA value equivalent to v8.1.0 - see github.com/astral-sh/setup-uv#usage
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         python-version: "3.11"
     - name: Create uv env with dev dependency group

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -124,7 +124,7 @@ jobs:
 
     - name: codecov
       if: ${{ github.repository == 'MDAnalysis/membrane-curvature' }}
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -123,7 +123,7 @@ jobs:
 
     - name: codecov
       if: ${{ github.repository == 'MDAnalysis/membrane-curvature' }}
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -101,7 +101,7 @@ jobs:
     # More info on options: https://github.com/conda-incubator/setup-miniconda
     # An environment for the minimum versions
     - name: setup micromamba
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
       with:
         environment-file: devtools/conda-envs/test_${{ matrix.env_file }}.yaml
         environment-name: test

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -100,7 +100,7 @@ jobs:
     # More info on options: https://github.com/conda-incubator/setup-miniconda
     # An environment for the minimum versions
     - name: setup micromamba
-      uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
+      uses: mamba-org/setup-micromamba@4b9113af4fba0e9e1124b252dd6497a419e7396d # v1
       with:
         environment-file: devtools/conda-envs/test_${{ matrix.env_file }}.yaml
         environment-name: test

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,7 +53,7 @@ jobs:
           echo "Extracted version: $VERSION"
 
       - name: Upload dist files
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist-files
           path: dist/
@@ -138,7 +138,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   verify-testpypi-install:
     name: Verify install from TestPyPI

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
 
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
 
@@ -156,7 +156,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
 
@@ -190,7 +190,7 @@ jobs:
       (github.event_name == 'release' && github.event.action == 'published')
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
       version: ${{ steps.extract-version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -65,7 +65,7 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -153,7 +153,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -195,7 +195,7 @@ jobs:
           python-version: "3.14"
 
       - name: Checkout repository for actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Wait for version to be available on PyPI (30 seconds)
         run: sleep 30

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -113,7 +113,7 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -73,7 +73,7 @@ jobs:
           python-version: "3.14"
 
       - name: Download dist files
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-files
           path: dist/
@@ -107,7 +107,7 @@ jobs:
       id-token: write #OIDC token
     steps:
       - name: Download dist files
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-files
           path: dist/
@@ -132,7 +132,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download dist files
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-files
           path: dist/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Membranecurvature CHANGELOG
 =============================
 
+* Replaced action version with specific commit hash in github actions (PR #224)
 * Include tests in coverage report; set Codecov threshold to 100% (PR #219)
 * Added brick-wall FFT filtering to the binning surface method (PR #188)
 * Added `uv.lock` file and step in CI to validate uv environment with dev dependency group (PR #202)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Membranecurvature CHANGELOG
 =============================
 
-* Replaced action version with specific commit hash in github actions (PR #224)
+* Replaced action version with specific commit hash in github actions and added dependabot cfg file (PR #224)
 * Include tests in coverage report; set Codecov threshold to 100% (PR #219)
 * Added brick-wall FFT filtering to the binning surface method (PR #188)
 * Added `uv.lock` file and step in CI to validate uv environment with dev dependency group (PR #202)


### PR DESCRIPTION
<!--
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #196 and #219 

Dependabot has been enabled for all repos in the organization.

## Description
<!--
Provide a brief description of the PR's purpose here.
-->

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use a bullet list. -->
Replaced:
- checkout action version with hash v7.0.0
- setup python action version with hash v6.2.0
- download artifact action version with hash v8.0.1
- upload artifact action version with hash v7.0.1
- publish PyPI v1.14.0
- setup micromamba action version with hash v1.0.0
- codecov action version with hash v7.0.0
- Added dependabot config file

I upgraded some actions in the process too:
- checkout v6 -> v7
- setup-python v6 -> v6.2.0

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [N/A] Tests updated/added?
 - [N/A] Documentation updated/added?
 - [x] `CHANGELOG` file updated?
