### PR TITLE
Refact: Set `fft_filter=None` as default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Membranecurvature CHANGELOG
 =============================
 
+* Set ``fft_filter`` to ``None`` as default (PR #239)
 * Refact: Calculate Fourier coeffs in SVD with `np.dot` instead of matmul (PR #223)
 * Remove side effect - MDAnalysis logging at import (PR #221)
 * Fixed stale project metadata and updated README files (PR #218)

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ gaussian_frame_10 = curvature_upper_leaflet.results.gaussian[10]
 
 ### With the binning method
 
-The same example run with the binning surface method looks like:
+The same example run with the binning method looks like:
 
 ```python
 import MDAnalysis as mda
@@ -137,7 +137,38 @@ from MDAnalysis.tests.datafiles import Martini_membrane_gro
 
 universe = mda.Universe(Martini_membrane_gro)
 
-# run with the binning surface_method with FFT filtering
+curvature_upper_leaflet_binning = MembraneCurvature(universe,
+                                                   select='resid 1-225 and name PO4',
+                                                   surface_method='binning',
+                                                   n_x_bins=8,
+                                                   n_y_bins=8,
+                                                   ).run()
+
+# extract average surface
+surface_upper_leaflet_binning = curvature_upper_leaflet_binning.results.average_z_surface
+
+# extract average mean curvature
+mean_upper_leaflet_binning = curvature_upper_leaflet_binning.results.average_mean
+
+# extract average Gaussian curvature
+gaussian_upper_leaflet_binning = curvature_upper_leaflet_binning.results.average_gaussian
+```
+
+> [!TIP]
+> The default filtering is disabled. Omit the `fft_filter` argument to use the default.
+
+#### Binning with FFT filtering
+
+Alternatively, to apply filtering to the surface, pass ``fft_filter='auto'``:
+
+```python
+import MDAnalysis as mda
+from membrane_curvature import MembraneCurvature
+from MDAnalysis.tests.datafiles import Martini_membrane_gro
+
+universe = mda.Universe(Martini_membrane_gro)
+
+# run with the binning surface_method with automatic FFT filtering
 curvature_upper_leaflet_binning = MembraneCurvature(universe,
                                                     select='resid 1-225 and name PO4',
                                                     surface_method='binning',
@@ -159,38 +190,6 @@ gaussian_upper_leaflet_binning = curvature_upper_leaflet_binning.results.average
 > [!NOTE]
 >
 > FFT filtering is only available with `surface_method='binning'`. Per-frame `results.z_surface`, `results.mean`, and `results.gaussian` are not FFT-filtered. With filtering enabled, `results.average_z_surface`, `results.average_mean`, and `results.average_gaussian` are computed from the filtered average height. Check the [Algorithm] page for more details on empty bins, periodic boundaries, and manual $q_{low} > 0$ caveats.
-
-> [!TIP]
->
-> The parameter ``fft_filter='auto'`` is already default for the binning method. If you are using this default, you can omit it from the constructor.
-
-Alternatively, to get the raw time average of the surface without filtering, pass ``fft_filter=None``:
-
-```python
-import MDAnalysis as mda
-from membrane_curvature import MembraneCurvature
-from MDAnalysis.tests.datafiles import Martini_membrane_gro
-
-universe = mda.Universe(Martini_membrane_gro)
-
-# run with the binning surface_method without FFT filtering
-curvature_upper_leaflet_binning = MembraneCurvature(universe,
-                                                    select='resid 1-225 and name PO4',
-                                                    surface_method='binning',
-                                                    n_x_bins=8,
-                                                    n_y_bins=8,
-                                                    fft_filter=None,
-                                                    wrap=True).run()
-
-# extract average surface
-surface_upper_leaflet_binning = curvature_upper_leaflet_binning.results.average_z_surface
-
-# extract average mean curvature
-mean_upper_leaflet_binning = curvature_upper_leaflet_binning.results.average_mean
-
-# extract average Gaussian curvature
-gaussian_upper_leaflet_binning = curvature_upper_leaflet_binning.results.average_gaussian
-```
 
 You can find more examples on how to run MembraneCurvature in the [Usage] page.
 To plot results from MembraneCurvature please check the [Visualization] page.

--- a/docs/source/pages/Algorithm.rst
+++ b/docs/source/pages/Algorithm.rst
@@ -467,19 +467,21 @@ associated functions.
 3.2.1.1. FFT filtering on the averaged surface (``fft_filter``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A brick-wall filter is applied to the averaged surface once all frames have been processed
-when ``surface_method='binning'`` and the argument ``fft_filter`` is set to ``'auto'`` (default) or
-passed as a dictionary like ``{'q': (q_low, q_high)}``.
+A brick-wall filter is available when running with ``surface_method='binning'`` and the argument
+``fft_filter``. By default, ``fft_filter`` is set to ``None``. When set to ``'auto'``, the
+brick-wall filter is applied with the default low-pass ``(0, 0.5 * q_Nyq)`` from ``dx`` and ``dy``.
+This filter is applied to the averaged surface once all frames have been processed. An additional
+option is to pass a dictionary like ``{'q': (q_low, q_high)}`` to set the pass-band limits manually.
 
 .. important::
 
   **The FFT filter is not applied to per-frame surfaces**.  Filtering is performed on the
   time-averaged height field, where thermal fluctuations have already been suppressed by averaging.
 
-Pass-band limits are resolved at construction time via
-:func:`~membrane_curvature.fft_filtering.resolve_fft_filter` and applied at the end
-of the run with :func:`~membrane_curvature.fft_filtering.apply_fft_filter` (see
-:mod:`~membrane_curvature.fft_filtering`).
+For both the ``'auto'`` and manual modes, the pass-band limits are resolved at construction time via
+:func:`~membrane_curvature.fft_filtering.resolve_fft_filter` and applied at the end of the run with
+:func:`~membrane_curvature.fft_filtering.apply_fft_filter`. See 
+:mod:`~membrane_curvature.fft_filtering` for more details.
 
 |fft_filter_plot|
 
@@ -488,16 +490,15 @@ averages the height field (:attr:`~membrane_curvature.base.MembraneCurvature.res
 over the trajectory and then smooths it in reciprocal space by zeroing all Fourier modes outside
 the pass band defined by :math:`q_{\mathrm{low}} \leq |q| \leq q_{\mathrm{high}}` via
 :func:`~membrane_curvature.fft_filtering.apply_fft_filter` before transforming back to real space.
-The resulting filtered surface is stored in :attr:`~membrane_curvature.base.MembraneCurvature.results.average_z_surface`,
-and then used to calculate mean and Gaussian curvature via :func:`~membrane_curvature.curvature.mean_curvature` and
+The resulting filtered surface is stored in
+:attr:`~membrane_curvature.base.MembraneCurvature.results.average_z_surface`, and then used to
+calculate mean and Gaussian curvature via :func:`~membrane_curvature.curvature.mean_curvature` and
 :func:`~membrane_curvature.curvature.gaussian_curvature`, respectively.
 
-With the default ``fft_filter='auto'``, the pass band is :math:`(0,\ 0.5\,q_{\mathrm{Nyq}})`,
+With ``fft_filter='auto'``, the pass band is :math:`(0,\ 0.5\,q_{\mathrm{Nyq}})`,
 a conservative low-pass by default which retains the large-scale membrane shape while
-suppressing short-wavelength noise.
-
-For binning, filtering defaults to ``fft_filter='auto'``. To control the band manually,
-pass ``fft_filter={'q': (q_low, q_high)}`` in rad/Å. To disable filtering altogether, pass ``fft_filter=None``.
+suppressing short-wavelength noise. To control the band manually, pass
+``fft_filter={'q': (q_low, q_high)}`` in rad/Å. The filter is disabled by default.
 
 .. warning::
 

--- a/docs/source/pages/Usage.rst
+++ b/docs/source/pages/Usage.rst
@@ -183,9 +183,9 @@ solution, but the coefficients are not uniquely determined by the data.
 2.1.2 Binning surface method
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Alternatively, set ``surface_method='binning'`` and provide the values for
-the binning grid ``n_x_bins`` and ``n_y_bins``. Note that you need to apply
-coordinate wrapping with ``wrap=True``:
+Alternatively, set ``surface_method='binning'`` and provide the values for the binning grid
+``n_x_bins`` and ``n_y_bins``. Note that you need to apply coordinate wrapping with
+``wrap=True``. Since the default filtering is disabled, you can omit the ``fft_filter`` argument:
 
 .. code-block:: python
 
@@ -200,22 +200,12 @@ coordinate wrapping with ``wrap=True``:
                                                 surface_method='binning',
                                                 n_x_bins=8,
                                                 n_y_bins=8,
-                                                wrap=True
+                                                wrap=True,
                                                 ).run()
   
     mean_upper_leaflet = curvature_upper_leaflet.results.average_mean
 
     gaussian_upper_leaflet = curvature_upper_leaflet.results.average_gaussian
-
-By default, binning uses ``fft_filter='auto'``, so the ``average_z_surface`` map above is
-computed from the FFT-filtered time-averaged height (see :ref:`fft-filtering`). 
-
-.. warning
-
-  Per-frame ``results.z_surface``, ``results.mean``, and ``results.gaussian``
-  stay unfiltered.
-
-You can find more detailed examples in the notebooks available in the :ref:`tutorials` page.
 
 
 .. _fft-filtering:
@@ -224,8 +214,8 @@ You can find more detailed examples in the notebooks available in the :ref:`tuto
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. warning::
-  FFT filtering is available only with ``surface_method='binning'``. It does **not**
-  filter each frame. 
+  FFT filtering is available only with ``surface_method='binning'``. Per-frame
+  ``results.z_surface``, ``results.mean``, and ``results.gaussian`` stay unfiltered.
   
 The order of operations is:
 
@@ -235,8 +225,9 @@ The order of operations is:
    ``results.average_mean`` and ``results.average_gaussian`` from the (possibly filtered)
    average height.
 
-Binning analyses use ``fft_filter='auto'`` by default (low-pass ``(0, 0.5 * q_Nyq)`` from
-``dx`` and ``dy``). Pass ``fft_filter=None`` to disable filtering on the average map.
+By default, binning uses ``fft_filter=None``. With the auto filtering mode ``fft_filter="auto"``,
+the brick-wall filter is set to ``(0, 0.5 * q_Nyq)``, where $q_{low}$ is set to 0 and $q_{high}$
+is set to 0.5 * q_Nyq from ``dx`` and ``dy``.
 
 
 .. code-block:: python
@@ -254,10 +245,11 @@ Binning analyses use ``fft_filter='auto'`` by default (low-pass ``(0, 0.5 * q_Ny
 
   As shown above, MembraneCurvature allows custom values for the FFT filtering by passing a
   tuple of ``(q_low, q_high)`` in rad/Å to ``fft_filter={'q': (q_low, q_high)}``.
-  **However, this is not recommended!** Custom values should be used with caution.
+  **However, this is not recommended unless you know what you are doing. Custom values should
+  be used with caution.**
   
-  The recommended way is to use the automatic mode ``fft_filter='auto'`` with the default
-  low-pass ``(0, 0.5 * q_Nyq)`` from ``dx`` and ``dy``.
+  When using the brick-wall filter, the recommended way is to use the automatic mode
+  ``fft_filter='auto'`` with the default low-pass ``(0, 0.5 * q_Nyq)`` from ``dx`` and ``dy``.
 
 .. _membrane-protein:
 

--- a/membrane_curvature/base.py
+++ b/membrane_curvature/base.py
@@ -90,8 +90,8 @@ class MembraneCurvature(AnalysisBase):
         relative threshold on singular values.
     fft_filter : None, ``'auto'``, or dict, optional
         Brick-wall filter on the binned height field when ``surface_method='binning'``.
-        Default ``'auto'`` (low-pass ``(0, 0.5 * q_Nyq)`` from bin widths). Pass
-        ``None`` to disable. Pass ``{'q': (q_low, q_high)}`` for custom bounds in rad/Å.
+        Default is ``None``. Pass ``'auto'`` to enable automatic filtering with low-pass set
+        as ``(0, 0.5 * q_Nyq)``. For custom bounds in rad/Å, pass ``{'q': (q_low, q_high)}``.
         For **average** maps: time-average of ``z_surface``, filter once, then curvature
         on that filtered height. Per-frame arrays are not FFT-filtered. Ignored for
         ``surface_method='fourier'``.
@@ -215,7 +215,7 @@ class MembraneCurvature(AnalysisBase):
         fourier_m=2,
         fourier_n=2,
         fourier_rcond=None,
-        fft_filter='auto',
+        fft_filter=None,
         **kwargs,
     ):
 

--- a/membrane_curvature/fft_filtering.py
+++ b/membrane_curvature/fft_filtering.py
@@ -10,14 +10,14 @@ FFT filtering
 .. important::
 
     The brick-wall FFT filter is available only when :class:`~membrane_curvature.base.MembraneCurvature`
-    runs with ``surface_method='binning'``.
+    runs with ``surface_method='binning'``. Filtering defaults to ``fft_filter=None``.
+    Pass ``fft_filter='auto'`` to enable automatic filtering with low pass set as ``(0, 0.5 * q_Nyq)``.
 
     **Note that per-frame arrays are not FFT-filtered!**
 
     For average maps, :class:`~membrane_curvature.base.MembraneCurvature` applies the brick-wall
     filter once to the averaged ``z_surface`` and computes mean and Gaussian curvature on that filtered average.
 
-    For binning, filtering defaults to ``fft_filter='auto'``. Pass ``fft_filter=None`` to disable FFT filtering.
 
 This module implements a brick-wall filter on a binned height field in the reciprocal space.
 This implementation uses :func:`numpy.fft.fft2` with physical bin widths :math:`\Delta x` and
@@ -28,7 +28,11 @@ Usage
 
 Users can control filtering in three ways via the ``fft_filter`` argument:
 
-- **Automatic (default for binning):** ``fft_filter='auto'``
+- **Disabled (default for binning):** ``fft_filter=None``
+
+  No FFT filtering is applied to the time-averaged surface.
+
+- **Automatic:** ``fft_filter='auto'``
 
   Low-pass with ``q_high = 0.5 * q_Nyq``, resolved at runtime via
   :func:`resolve_fft_filter`.
@@ -36,10 +40,6 @@ Users can control filtering in three ways via the ``fft_filter`` argument:
 - **Manual:** ``fft_filter={'q': (q_low, q_high)}``
 
   Users explicitly specify the ``(q_low, q_high)`` pair in rad/Å.
-
-- **Disabled:** ``fft_filter=None``
-
-  No FFT filtering is applied to the time-averaged surface.
 
 .. warning::
 

--- a/membrane_curvature/tests/test_fft_filtering.py
+++ b/membrane_curvature/tests/test_fft_filtering.py
@@ -254,14 +254,20 @@ def test_membrane_curvature_fourier_without_fft_filter(universe_dummy_wrap):
     assert mc.fft_filter is None
 
 
-def test_membrane_curvature_binning_default_fft_filter_auto(universe_dummy_wrap):
+def test_membrane_curvature_binning_default_filter_is_none(universe_dummy_wrap):
+    mc = MembraneCurvature(universe_dummy_wrap, n_x_bins=3, n_y_bins=3, surface_method='binning').run()
+    assert mc.fft_filter is None
+    assert mc._fft_q_bounds is None
+
+
+def test_membrane_curvature_binning_fft_filter_auto(universe_dummy_wrap):
     n_bins = 3
     dx = dy = universe_dummy_wrap.dimensions[0] / n_bins
     expected_q_bounds = resolve_fft_filter('auto', dx, dy)
-    mc = MembraneCurvature(universe_dummy_wrap, n_x_bins=n_bins, n_y_bins=n_bins, surface_method='binning').run()
+    mc = MembraneCurvature(
+        universe_dummy_wrap, n_x_bins=n_bins, n_y_bins=n_bins, surface_method='binning', fft_filter='auto'
+    ).run()
     assert mc.fft_filter == 'auto'
-    assert mc.dx == dx
-    assert mc.dy == dy
     assert_allclose(mc._fft_q_bounds, expected_q_bounds)
 
 


### PR DESCRIPTION
<!--
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #236 

## Description
<!--
Provide a brief description of the PR's purpose here.
-->
Turn off `fft_filter` by default, it was running `'auto'`. This change will help changes in #238 be introduced more naturally. 

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use a bullet list. -->
- Set `fft_filter` as None in `base.py`.
- Updated docstring in `fft_filter.py`.
- Update doc pages: USage, Algorithm, README. 

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `CHANGELOG` file updated?
