### PR TITLE
Enhance: Speed up binning with masked `np.add.at` accumulation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 Membranecurvature CHANGELOG
 =============================
 
+---
+
+* Refactored binning surface method to use `np.add.at` for improved performance (PR #240)
 * Set ``fft_filter`` to ``None`` as default (PR #239)
 * Refact: Calculate Fourier coeffs in SVD with `np.dot` instead of matmul (PR #223)
 * Remove side effect - MDAnalysis logging at import (PR #221)

--- a/docs/api/surface_methods/binning_surface.rst
+++ b/docs/api/surface_methods/binning_surface.rst
@@ -1,3 +1,2 @@
 .. automodule:: membrane_curvature.binning_surface
    :members:
-   :exclude-members: WarnOnce

--- a/docs/source/pages/Algorithm.rst
+++ b/docs/source/pages/Algorithm.rst
@@ -339,9 +339,8 @@ index:
 and similarly for :math:`y`. 
 
 Atoms that map outside the valid bin range
-(negative indices or indices ≥ ``n_x_bins``/``n_y_bins``) are skipped and
-trigger a one-time detailed warning. The function uses a WarnOnce helper so the full diagnostic
-is shown on first occurrence and a short message on subsequent occurrences.
+(negative indices or indices ≥ ``n_x_bins``/``n_y_bins``) are skipped. A
+warning is issued reporting how many atoms fall outside the grid boundaries.
 
 To populate the grid, :class:`~membrane_curvature.base.MembraneCurvature` wraps
 the coordinates of the :class:`~MDAnalysis.core.groups.AtomGroup` of reference

--- a/membrane_curvature/binning_surface.py
+++ b/membrane_curvature/binning_surface.py
@@ -29,30 +29,6 @@ Functions
 
 import numpy as np
 import warnings
-import logging
-
-logger = logging.getLogger('MDAnalysis.MDAKit.membrane_curvature')
-
-
-class WarnOnce:
-    """
-    Class to warn atoms out of grid boundaries only once with full message.
-    After the first occurrence, message will be generic.
-    """
-
-    def __init__(self, msg, msg_multiple) -> None:
-        self.msg = msg
-        self.warned = False
-        self.warned_multiple = False
-        self.msg_multiple = msg_multiple
-
-    def warn(self, *args):
-        if not self.warned:
-            self.warned = True
-            warnings.warn(self.msg.format(*args))
-            logger.warning(self.msg.format(*args))
-        elif not self.warned_multiple:
-            warnings.warn(self.msg_multiple)
 
 
 def derive_surface(atoms, n_cells_x, n_cells_y, max_width_x, max_width_y):
@@ -84,24 +60,6 @@ def derive_surface(atoms, n_cells_x, n_cells_y, max_width_x, max_width_y):
     return get_z_surface(
         coordinates, n_x_bins=n_cells_x, n_y_bins=n_cells_y, x_range=(0, max_width_x), y_range=(0, max_width_y)
     )
-
-
-# messages for warnings, negative and positive coordinates.
-msg_exceeds = 'More than one atom exceed boundaries of grid.'
-negative_coord_warning = WarnOnce(
-    'Atom with negative coordinates falls '
-    'outside grid boundaries. Element '
-    "({},{}) in grid can't be assigned."
-    ' Skipping atom.',
-    msg_exceeds,
-)
-positive_coord_warning = WarnOnce(
-    'Atom coordinates exceed size of grid '
-    "and element ({},{}) can't be assigned. "
-    'Maximum (x,y) coordinates must be < ({}, {}). '
-    'Skipping atom.',
-    msg_exceeds,
-)
 
 
 def get_z_surface(coordinates, n_x_bins=10, n_y_bins=10, x_range=(0, 100), y_range=(0, 100)):
@@ -146,11 +104,8 @@ def get_z_surface(coordinates, n_x_bins=10, n_y_bins=10, x_range=(0, 100), y_ran
     np.add.at(grid_norm_unit, (cell_x_floor[valid_mask], cell_y_floor[valid_mask]), 1)
 
     if not np.all(valid_mask):
-        for index_l, index_m in zip(cell_x_floor[~valid_mask], cell_y_floor[~valid_mask]):
-            if index_l < 0 or index_m < 0:
-                negative_coord_warning.warn(index_l, index_m)
-            else:
-                positive_coord_warning.warn(index_l, index_m, x_range[1], y_range[1])
+        atoms_outside_grid = np.count_nonzero(~valid_mask)
+        warnings.warn(f'{atoms_outside_grid} atoms fall outside the grid boundaries. Skipping atoms.')
 
     z_surface = normalized_grid(grid_z_coordinates, grid_norm_unit)
 

--- a/membrane_curvature/binning_surface.py
+++ b/membrane_curvature/binning_surface.py
@@ -140,19 +140,18 @@ def get_z_surface(coordinates, n_x_bins=10, n_y_bins=10, x_range=(0, 100), y_ran
     cell_x_floor = np.floor(x_coords * x_factor).astype(int)
     cell_y_floor = np.floor(y_coords * y_factor).astype(int)
 
-    for index_l, index_m, index_z in zip(cell_x_floor, cell_y_floor, z_coords):
-        try:
-            # negative coordinates
+    valid_mask = (cell_x_floor >= 0) & (cell_y_floor >= 0) & (cell_x_floor < n_x_bins) & (cell_y_floor < n_y_bins)
+
+    for index_l, index_m, index_z in zip(cell_x_floor[valid_mask], cell_y_floor[valid_mask], z_coords[valid_mask]):
+        grid_z_coordinates[index_l, index_m] += index_z
+        grid_norm_unit[index_l, index_m] += 1
+
+    if not np.all(valid_mask):
+        for index_l, index_m in zip(cell_x_floor[~valid_mask], cell_y_floor[~valid_mask]):
             if index_l < 0 or index_m < 0:
                 negative_coord_warning.warn(index_l, index_m)
-                continue
-
-            grid_z_coordinates[index_l, index_m] += index_z
-            grid_norm_unit[index_l, index_m] += 1
-
-        # too large positive coordinates
-        except IndexError:
-            positive_coord_warning.warn(index_l, index_m, x_range[1], y_range[1])
+            else:
+                positive_coord_warning.warn(index_l, index_m, x_range[1], y_range[1])
 
     z_surface = normalized_grid(grid_z_coordinates, grid_norm_unit)
 

--- a/membrane_curvature/binning_surface.py
+++ b/membrane_curvature/binning_surface.py
@@ -142,9 +142,8 @@ def get_z_surface(coordinates, n_x_bins=10, n_y_bins=10, x_range=(0, 100), y_ran
 
     valid_mask = (cell_x_floor >= 0) & (cell_y_floor >= 0) & (cell_x_floor < n_x_bins) & (cell_y_floor < n_y_bins)
 
-    for index_l, index_m, index_z in zip(cell_x_floor[valid_mask], cell_y_floor[valid_mask], z_coords[valid_mask]):
-        grid_z_coordinates[index_l, index_m] += index_z
-        grid_norm_unit[index_l, index_m] += 1
+    np.add.at(grid_z_coordinates, (cell_x_floor[valid_mask], cell_y_floor[valid_mask]), z_coords[valid_mask])
+    np.add.at(grid_norm_unit, (cell_x_floor[valid_mask], cell_y_floor[valid_mask]), 1)
 
     if not np.all(valid_mask):
         for index_l, index_m in zip(cell_x_floor[~valid_mask], cell_y_floor[~valid_mask]):

--- a/membrane_curvature/tests/test_membrane_curvature.py
+++ b/membrane_curvature/tests/test_membrane_curvature.py
@@ -1299,7 +1299,7 @@ class TestMembraneCurvature(object):
     def test_positive_coordinates_exceed_grid(self, x_bin, y_bin, box_dim, dummy_array):
         u = mda.Universe(dummy_array, n_atoms=len(dummy_array))
         u.dimensions = [box_dim, box_dim, 300, 90.0, 90.0, 90.0]
-        regex = r'exceed boundaries | size of grid'
+        regex = r'atoms fall outside the grid boundaries'
         with pytest.warns(UserWarning, match=regex):
             MembraneCurvature(
                 u, select='all', surface_method='binning', fft_filter=None, n_x_bins=x_bin, n_y_bins=y_bin, wrap=False
@@ -1346,7 +1346,7 @@ class TestMembraneCurvature(object):
     def test_negative_coordinates_exceed_grid(self, x_bin, y_bin, box_dim, dummy_array):
         u = mda.Universe(dummy_array, n_atoms=len(dummy_array))
         u.dimensions = [box_dim, box_dim, 300, 90.0, 90.0, 90.0]
-        regex = r'exceed boundaries | coordinates falls'
+        regex = r'atoms fall outside the grid boundaries. Skipping atoms.'
         with pytest.warns(UserWarning, match=regex):
             MembraneCurvature(
                 u, select='all', surface_method='binning', fft_filter=None, n_x_bins=x_bin, n_y_bins=y_bin, wrap=False


### PR DESCRIPTION
<!--
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #225

## Description
<!--
Provide a brief description of the PR's purpose here.
-->
Faster binning surface using a masked grid and accumulting with `np.add.at`.

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use a bullet list. -->
- Built mask for valid grid -> replaces try/except
- Accumulate with `np.add.at` instead of running Python loop.
- Replace `WarnOnce` with a out of grid warning for total count.

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [N/A] Tests updated/added?
 - [N/A] Documentation updated/added?
 - [x] `CHANGELOG` file updated?
