### PR TITLE
docs: improve curvature equation references

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,6 @@ Chronological list of authors
 
 2024
   - Christopher Lee
+
+2026
+  - Arun

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Membranecurvature CHANGELOG
 =============================
 
+* Improve curvature API equation headings, references, and warning formatting (issue #241)
 * Set ``fft_filter`` to ``None`` as default (PR #239)
 * Refact: Calculate Fourier coeffs in SVD with `np.dot` instead of matmul (PR #223)
 * Remove side effect - MDAnalysis logging at import (PR #221)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -84,7 +84,8 @@ The functions in :mod:`~membrane_curvature.curvature` include both analytical an
    - With :mod:`~membrane_curvature.binning_surface`, **curvature is calculated numerically** from the discrete height
      field using finite differences.
 
-In both cases, the derivatives are then used to calculate mean and Gaussian curvature using the Monge-gauge formulas.
+In both cases, the derivatives are then used to calculate mean and Gaussian curvature using the Monge-gauge formulas
+for :eq:`mean curvature <mean-curvature-equation>` and :eq:`Gaussian curvature <gaussian-curvature-equation>`.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/pages/Algorithm.rst
+++ b/docs/source/pages/Algorithm.rst
@@ -542,7 +542,7 @@ associated functions.
 ^^^^^^^^^^^^^^^^^^^^
 
 Mean curvature :math:`H` is calculated from the five partial derivative
-arrays using the Monge-gauge formula:
+arrays using the Monge-gauge formula in :eq:`mean-curvature-equation`:
 
 .. math::
 
@@ -561,7 +561,7 @@ The result has units Å :sup:`-1` and is stored in
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Gaussian curvature :math:`K` is calculated from the same derivative
-arrays using:
+arrays using the Monge-gauge formula in :eq:`gaussian-curvature-equation`:
 
 .. math::
 

--- a/membrane_curvature/curvature.py
+++ b/membrane_curvature/curvature.py
@@ -12,16 +12,30 @@ With the Monge gauge formulas, we map first derivatives :math:`(\partial_x, \par
 and mixed derivatives :math:`(\partial_{xx}, \partial_{yy}, \partial_{xy})` to the definitions of
 curvature.
 
-Mean curvature :math:`H`, defined by:
+Monge-gauge equations
+---------------------
 
-.. math:: H =
-    \frac{(1+\partial_x^2)\partial_{yy}+(1+\partial_y^2)\partial_{xx}-2\partial_x\partial_y\partial_{xy}}
-    {2(1+\partial_x^2+\partial_y^2)^{3/2}},
+Mean curvature
+^^^^^^^^^^^^^^
 
-and Gaussian curvature :math:`K`, defined by:
+Mean curvature :math:`H` is defined by:
 
-.. math:: K = \frac{\partial_{xx}\partial_{yy}-\partial_{xy}^2}
-   {(1+\partial_x^2+\partial_y^2)^2}.
+.. math::
+    :label: mean-curvature-equation
+
+    H = \frac{(1+\partial_x^2)\partial_{yy}+(1+\partial_y^2)\partial_{xx}-2\partial_x\partial_y\partial_{xy}}
+             {2(1+\partial_x^2+\partial_y^2)^{3/2}},
+
+Gaussian curvature
+^^^^^^^^^^^^^^^^^^
+
+Gaussian curvature :math:`K` is defined by:
+
+.. math::
+    :label: gaussian-curvature-equation
+
+    K = \frac{\partial_{xx}\partial_{yy}-\partial_{xy}^2}
+             {(1+\partial_x^2+\partial_y^2)^2}.
 
 
 The Monge gauge formulas are implemented separately in the helpers
@@ -51,11 +65,11 @@ and units of Gaussian curvature are [length] :sup:`-2`.
 
 .. warning::
 
-    Numpy cannot calculate the gradient for arrays with inner array of
-    `length==1` unless `axis=0` is specified. Therefore in the functions here included
-    for mean and Gaussian curvature, shape of arrays must be at least (2,2).
-    In general, to calculate a numerical gradients shape of arrays must be >=(`edge_order` +
-    1).
+    NumPy cannot calculate the gradient for arrays with an inner array of
+    ``length == 1`` unless ``axis=0`` is specified. Therefore, for the mean and
+    Gaussian curvature functions included here, the shape of arrays must be at
+    least ``(2, 2)``. In general, to calculate numerical gradients, the shape of
+    arrays must be at least ``edge_order + 1``.
 
 For a periodic **Fourier** fit to atom heights, use
 :func:`~membrane_curvature.fourier_surface.fourier_height_from_atoms` or


### PR DESCRIPTION
## Summary
- add titled, labeled Monge-gauge equations to the curvature API docs
- link the mean and Gaussian equations from the API overview and algorithm guide
- fix the curvature warning formatting and wording

## Validation
- focused Sphinx build with warnings treated as errors
- pre-commit hooks on all changed files

Fixes MDAnalysis/membrane-curvature#241

Contributed by @ANONYMOUSZED-beep.