### PR TITLE
Feature: Add `binning_nearest` as surface method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Membranecurvature CHANGELOG
 
 ---
 
+* Added ``surface_method='binning_nearest'`` as a new surface method (PR #246)
 * Feature: Added periodic edge padding for the binning surface method (PR #238)
 * Refactored binning surface method to use ``np.add.at`` for improved performance (PR #240)
 * Set ``fft_filter`` to ``None`` as default (PR #239)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,17 +3,18 @@ MembraneCurvature's API Documentation
 **************************************
 
 The MembraneCurvature API is built around the :class:`~membrane_curvature.base.MembraneCurvature` class, which loads trajectory and coordinate
-data, and provides routines to derive a surface from atom positions. The resulting surface is then used to compute mean and Gaussian curvature,
+files, and provides routines to derive a surface from atom positions. The resulting surface is then used to compute mean and Gaussian curvature,
 either for individual frames or averaged across multiple frames of an MD trajectory.
 
 To use :class:`~membrane_curvature.base.MembraneCurvature`, users must provide at least two inputs: an MDAnalysis
 :class:`~MDAnalysis.core.universe.Universe`, and an :class:`~MDAnalysis.core.groups.AtomGroup` used as the reference to derive the surface and
 calculate curvature.
 
-:class:`~membrane_curvature.base.MembraneCurvature` supports two different methods to derive surfaces from reference atoms:
+:class:`~membrane_curvature.base.MembraneCurvature` supports three different methods to derive surfaces from reference atoms:
 
 - :mod:`~membrane_curvature.fourier_surface` — the default method.
 - :mod:`~membrane_curvature.binning_surface` — selected explicitly by ``surface_method='binning'``.
+- :mod:`~membrane_curvature.binning_nearest_surface` - selected explicitly by ``surface_method='binning_nearest'``.
 
 The height coordinates from the selected ``AtomGroup`` are extracted, and then used to reconstruct the surface using the specified surface derivation method.
 Once the surface has been generated, mean and Gaussian curvature are calculated.
@@ -27,7 +28,7 @@ MembraneCurvature class
 =======================
 
 The :class:`~membrane_curvature.base.MembraneCurvature` class provides the main entrypoint to calculate mean and Gaussian curvature from a
-surface derived from a reference atom selection. See the API docs for 
+surface derived from a reference atom selection.
 
 .. toctree::
    :maxdepth: 1
@@ -51,7 +52,8 @@ of the atoms in the selected ``AtomGroup`` of reference.
 Surface Methods
 ===============
 
-``MembraneCurvature`` supports two different methods to derive a surface from the selected reference atoms:
+:class:`~membrane_curvature.base.MembraneCurvature` supports three different methods to derive a surface from the selected
+reference atoms:
 
 .. toctree::
    :maxdepth: 1
@@ -59,19 +61,22 @@ Surface Methods
 
    api/surface_methods/fourier_surface
    api/surface_methods/binning_surface
+   api/surface_methods/binning_nearest_surface
    api/surface_methods/padding
    api/surface_methods/fft_filtering
 
-:mod:`~membrane_curvature.fourier_surface` fits a periodic 2D Fourier sum to atom heights by linear least squares at each frame,
-evaluates the fitted surface, and obtains partial derivatives analytically from that sum.
+- :mod:`~membrane_curvature.fourier_surface` fits a periodic 2D Fourier sum to atom heights by linear least squares fit at each frame,
+  evaluates the fitted surface, and obtains partial derivatives analytically from that sum.
 
-:mod:`~membrane_curvature.binning_surface` assigns atoms to a regular grid, stores the mean height per cell, and estimates partial derivatives
-using the physical bin spacing with finite differences.
+- :mod:`~membrane_curvature.binning_surface` assigns atoms to a regular grid, stores the mean height per cell, and estimates partial derivatives
+  using the physical bin spacing with finite differences.
 
-The binning method supports:
+- :mod:`~membrane_curvature.binning_nearest_surface` assigns each grid corner the ``z`` of the nearest lipid in the ``xy`` plane
+  (minimum-image distances) and estimates partial derivatives with finite differences using the physical bin spacing.
 
-- A :mod:`~membrane_curvature.padding` option for orthorhombic boxes, which reduces finite difference artifacts.
-- A :mod:`~membrane_curvature.fft_filtering` option to remove high-frequency noise from the height field.
+Binning methods support a :mod:`~membrane_curvature.padding` option for orthorhombic boxes, which reduces finite difference artifacts, and a
+a brick-wall filter to remove high-frequency noise from the height field. The filter is applied to the height field before calculating curvature.
+:mod:`~membrane_curvature.fft_filtering` provides the functions to apply the filter and to resolve the pass-band limits.
 
 Curvature
 =========
@@ -83,8 +88,8 @@ The functions in :mod:`~membrane_curvature.curvature` include both analytical an
    The calculation of mean and Gaussian curvature differs between the two methods:
 
    - With :mod:`~membrane_curvature.fourier_surface`, **curvature is calculated analytically** from the fitted surface.
-   - With :mod:`~membrane_curvature.binning_surface`, **curvature is calculated numerically** from the discrete height
-     field using finite differences.
+   - With :mod:`~membrane_curvature.binning_surface` or :mod:`~membrane_curvature.binning_nearest_surface`, **curvature is calculated numerically**
+     from the discrete height field using finite differences.
 
 In both cases, the derivatives are then used to calculate mean and Gaussian curvature using the Monge-gauge formulas.
 

--- a/docs/api/surface_methods/binning_nearest_surface.rst
+++ b/docs/api/surface_methods/binning_nearest_surface.rst
@@ -1,3 +1,4 @@
 .. automodule:: membrane_curvature.binning_nearest_surface
    :members:
+   :private-members: _z_surface_from_nearest
 

--- a/docs/api/surface_methods/binning_nearest_surface.rst
+++ b/docs/api/surface_methods/binning_nearest_surface.rst
@@ -1,0 +1,3 @@
+.. automodule:: membrane_curvature.binning_nearest_surface
+   :members:
+

--- a/membrane_curvature/__init__.py
+++ b/membrane_curvature/__init__.py
@@ -16,6 +16,10 @@ from .binning_surface import (
     derive_surface as derive_surface,
     get_z_surface as get_z_surface,
 )
+from .binning_nearest_surface import (
+    get_z_surface_nearest as get_z_surface_nearest,
+    lipid_center_positions as lipid_center_positions,
+)
 from .curvature import (
     mean_curvature as mean_curvature,
     gaussian_curvature as gaussian_curvature,

--- a/membrane_curvature/base.py
+++ b/membrane_curvature/base.py
@@ -90,7 +90,7 @@ class MembraneCurvature(AnalysisBase):
         each frame and evaluates Monge-gauge curvature from analytic derivatives
         on the same bin grid (bin centers). ``binning`` derives the surface by creating
         a grid and assigning atoms to bins. It uses :func:`numpy.gradient` for derivatives.
-        ``binning_nearest`` assigns each bin the ``z`` of the nearest lipid in
+        ``binning_nearest`` assigns each grid corner the ``z`` of the nearest lipid in
         ``xy`` (minimum-image).
     grid_origin : {'box', 'lipid_bbox'}, optional
         xy grid extent for ``surface_method='binning_nearest'``. Default ``'box'``
@@ -107,13 +107,13 @@ class MembraneCurvature(AnalysisBase):
         when ``surface_method='fourier'``. The cutoff is interpreted as a
         relative threshold on singular values.
     fft_filter : None, ``'auto'``, or dict, optional
-        Brick-wall filter on the binned height field when ``surface_method='binning'``.
-        Default is ``None``. Pass ``'auto'`` to enable automatic filtering with low-pass set
-        as ``(0, 0.5 * q_Nyq)``. For custom bounds in rad/Å, pass ``{'q': (q_low, q_high)}``.
-        For **average** maps: time-average of ``z_surface``, filter once, then curvature
-        on that filtered height. Per-frame arrays are not FFT-filtered. Ignored for
-        ``surface_method='fourier'``. Compatible with ``padding``.
-        Not allowed with ``grid_origin='lipid_bbox'``.
+        Brick-wall filter on the binned height field for ``surface_method='binning'`` and
+        ``surface_method='binning_nearest'``. Default is ``None``. Pass ``'auto'`` to enable
+        automatic filtering with low-pass set to ``(0, 0.5 * q_Nyq)``. For custom bounds in
+        rad/Å, pass ``{'q': (q_low, q_high)}``. For **average** maps: time-average of
+        ``z_surface``, filter once, then curvature on that filtered height.
+        Per-frame arrays are not FFT-filtered. Ignored for ``surface_method='fourier'``.
+        Compatible with ``padding``. Not allowed with ``grid_origin='lipid_bbox'``.
     padding : bool, optional
         Apply periodic edge padding for binning surface methods. Default ``False``.
         For ``surface_method='binning'``, pads the simulation box using periodic images
@@ -130,7 +130,7 @@ class MembraneCurvature(AnalysisBase):
     ----------
     results.z_surface : ndarray
         Per-frame height field from the atom selection (unfiltered when
-        ``fft_filter`` is used with `surface_method='binning'`).
+        ``fft_filter`` is used with ``binning`` or ``binning_nearest``).
         Shape (`n_frames`, `n_x_bins`, `n_y_bins`).
     results.mean : ndarray
         Per-frame mean curvature associated with the surface.
@@ -139,19 +139,19 @@ class MembraneCurvature(AnalysisBase):
         Per-frame Gaussian curvature associated with the surface.
         Array of shape (`n_frames`, `n_x_bins`, `n_y_bins`)
     results.average_z_surface : ndarray
-        Average of the array elements in `z_surface`. With binning and
-        ``fft_filter`` enabled, this is the FFT-filtered temporal mean of ``z_surface``,
-        not the mean of per-frame filtered surfaces.
+        Average of the array elements in `z_surface`. With ``binning`` or
+        ``binning_nearest`` and ``fft_filter`` enabled, this is the FFT-filtered
+        temporal mean of ``z_surface``, not the mean of per-frame filtered surfaces.
         Each array has shape (`n_x_bins`, `n_y_bins`)
     results.average_mean : ndarray
-        Average of the array elements in `mean_curvature`. With binning
-        and ``fft_filter`` enabled, curvature of the filtered time-averaged height
-        (not the time average of per-frame ``results.mean``).
+        Average of the array elements in `mean_curvature`. With ``binning`` or
+        ``binning_nearest`` and ``fft_filter`` enabled, curvature of the filtered
+        time-averaged height (not the time average of per-frame ``results.mean``).
         Each array has shape (`n_x_bins`, `n_y_bins`)
     results.average_gaussian : ndarray
-        Average of the array elements in `gaussian_curvature`. With
-        binning and ``fft_filter`` enabled, curvature of the filtered time-averaged
-        height (not the time average of per-frame ``results.gaussian``).
+        Average of the array elements in `gaussian_curvature`. With ``binning`` or
+        ``binning_nearest`` and ``fft_filter`` enabled, curvature of the filtered
+        time-averaged height (not the time average of per-frame ``results.gaussian``).
         Each array has shape (`n_x_bins`, `n_y_bins`)
 
     Raises

--- a/membrane_curvature/base.py
+++ b/membrane_curvature/base.py
@@ -10,10 +10,10 @@ MembraneCurvature
 for calculating mean and Gaussian curvature from atom selections.
 
 It derives a height surface from the selected reference atoms using either the
-``"fourier"`` method (default) or the ``"binning"`` method, then evaluates
-curvature on the resulting surface. The specific operations used to derive
-the surface depend on the method selected by the user
-in the parameter :attr:`~membrane_curvature.base.MembraneCurvature.surface_method`.
+``"fourier"`` method (default) or binning methods (``"binning"`` or ``"binning_nearest"``),
+method, then evaluates curvature on the resulting surface. The specific operations used to derive
+the surface depend on the method selected by the user in the parameter
+:attr:`~membrane_curvature.base.MembraneCurvature.surface_method`.
 
 The set of required parameters to run :class:`~membrane_curvature.base.MembraneCurvature` varies depending
 on the selected ``surface_method``:
@@ -28,7 +28,8 @@ on the selected ``surface_method``:
     Required parameters are the number of bins in the x and y directions ``n_x_bins`` and ``n_y_bins``.
     Optional ``wrap`` parameter to control whether to wrap the coordinates exceeding the simulation box dimensions.
     Optional ``padding`` applies a periodic buffer before finite differences (in orthorhombic boxes only);
-    ``edge_pad_bins`` sets the buffer width in bins (default ``2``).
+    ``edge_pad_bins`` sets the buffer width in bins (default ``2``). Also available for
+    ``surface_method='binning_nearest'`` (wrap-pad of the nearest-lipid height field).
 
 Mean curvature is calculated in units of Å :sup:`-1` and Gaussian curvature in units of Å :sup:`-2`.
 """
@@ -36,6 +37,7 @@ Mean curvature is calculated in units of Å :sup:`-1` and Gaussian curvature in 
 import numpy as np
 import warnings
 from .binning_surface import get_z_surface
+from .binning_nearest_surface import get_z_surface_nearest
 from .curvature import (
     mean_curvature,
     gaussian_curvature,
@@ -55,6 +57,7 @@ from .fourier_validators import validate_positive_bin_counts
 from MDAnalysis.analysis.base import AnalysisBase
 
 import logging
+from enum import StrEnum
 
 logger = logging.getLogger('MDAnalysis.MDAKit.membrane_curvature')
 
@@ -82,11 +85,16 @@ class MembraneCurvature(AnalysisBase):
         Range of coordinates (min, max) in the x dimension.
     y_range : tuple of (float, float), optional, default: (0, `universe.dimensions[1]`)
         Range of coordinates (min, max) in the y dimension.
-    surface_method : {'binning', 'fourier'}, optional
+    surface_method : {'binning', 'binning_nearest', 'fourier'}, optional
         ``fourier`` (default) fits a periodic Fourier sum to atom positions at
         each frame and evaluates Monge-gauge curvature from analytic derivatives
         on the same bin grid (bin centers). ``binning`` derives the surface by creating
         a grid and assigning atoms to bins. It uses :func:`numpy.gradient` for derivatives.
+        ``binning_nearest`` assigns each bin the ``z`` of the nearest lipid in
+        ``xy`` (minimum-image).
+    grid_origin : {'box', 'lipid_bbox'}, optional
+        xy grid extent for ``surface_method='binning_nearest'``. Default ``'box'``
+        (``[0, lx]``, ``[0, ly]``).
     fourier_m : int, optional
         Maximum Fourier mode index in ``x`` when ``surface_method='fourier'``.
         Default ``2``.
@@ -105,11 +113,15 @@ class MembraneCurvature(AnalysisBase):
         For **average** maps: time-average of ``z_surface``, filter once, then curvature
         on that filtered height. Per-frame arrays are not FFT-filtered. Ignored for
         ``surface_method='fourier'``. Compatible with ``padding``.
+        Not allowed with ``grid_origin='lipid_bbox'``.
     padding : bool, optional
-        Apply periodic edge padding for ``surface_method='binning'``. Default ``False``.
-        Pads the simulation box using periodic images in ``x`` and ``y``, compute surface
-        and curvature on the padded grid, then clip back to ``(n_x_bins, n_y_bins)``.
-        Requires an orthorhombic box. Invalid with ``surface_method='fourier'``.
+        Apply periodic edge padding for binning surface methods. Default ``False``.
+        For ``surface_method='binning'``, pads the simulation box using periodic images
+        in ``x`` and ``y``, computes surface and curvature on the padded grid, then
+        clips back to ``(n_x_bins, n_y_bins)``. For ``surface_method='binning_nearest'``,
+        builds the nearest-lipid height field on the primary grid and evaluates curvature
+        with a wrap-pad buffer of ``edge_pad_bins``. Requires an orthorhombic box.
+        Invalid with ``surface_method='fourier'`` and with ``grid_origin='lipid_bbox'``.
     edge_pad_bins : int, optional
         Buffer width in bins on each side when ``padding=True`` (default ``2``).
         Ignored when ``padding=False``.
@@ -148,7 +160,8 @@ class MembraneCurvature(AnalysisBase):
         If ``n_x_bins`` or ``n_y_bins`` is not a positive integer
         (see :func:`~membrane_curvature.fourier_validators.validate_positive_bin_counts`),
         if the selection is empty, if ``surface_method`` is not one of
-        ``'binning'`` or ``'fourier'``, or, when ``surface_method='fourier'``,
+        ``'binning'``, ``'binning_nearest'``, or ``'fourier'``, or, when
+        ``surface_method='fourier'``,
         if ``fourier_m`` / ``fourier_n`` are negative or the selection has fewer
         atoms than Fourier parameters, if ``wrap=True`` with
         ``surface_method='fourier'``, if a manual ``fft_filter`` dict is passed
@@ -182,9 +195,12 @@ class MembraneCurvature(AnalysisBase):
     For membrane-protein systems without position restraints, preprocessing should include
     rotational and translational fitting around the protein.
 
-    Padding is only available for orthorhombic boxes. With ``padding=True``, finite differences
-    run on a padded height field built from periodic images, then the buffer of ``edge_pad_bins``
-    on each side is clipped so stored arrays keep the primary grid shape.
+    Padding is only available for orthorhombic boxes. With ``padding=True`` and
+    ``surface_method='binning'``, finite differences run on a padded height field built
+    from periodic atom images, then the buffer of ``edge_pad_bins`` on each side is
+    clipped so stored arrays keep the primary grid shape. With
+    ``surface_method='binning_nearest'``, the nearest-lipid height is built on the
+    primary grid and curvature uses a wrap-pad buffer of the same width.
     The default ``edge_pad_bins=2``, which uses two bins on each side for padding, is enough to
     reduce finite difference artifacts at edges and corners.
 
@@ -197,7 +213,7 @@ class MembraneCurvature(AnalysisBase):
 
     The attributes :attr:`~MembraneCurvature.results.average_mean` and
     :attr:`~MembraneCurvature.results.average_gaussian` contain mean and
-    Gaussian curvature maps for analysis and plotting; with ``fft_filter`` on
+    Gaussian curvature maps for analysis and plotting. With ``fft_filter`` on
     binning surfaces they are curvatures of the filtered average height, not the
     time average of per-frame curvatures.
 
@@ -227,6 +243,13 @@ class MembraneCurvature(AnalysisBase):
 
     """
 
+    class SurfaceMethod(StrEnum):
+        """Allowed values for ``surface_method``."""
+
+        BINNING = 'binning'
+        BINNING_NEAREST = 'binning_nearest'
+        FOURIER = 'fourier'
+
     def __init__(
         self,
         universe,
@@ -243,19 +266,19 @@ class MembraneCurvature(AnalysisBase):
         fft_filter=None,
         padding=False,
         edge_pad_bins=2,
+        grid_origin='box',
         **kwargs,
     ):
 
         super().__init__(universe.universe.trajectory, **kwargs)
         self.ag = universe.select_atoms(select)
-        # Validate selection up front so an empty AtomGroup produces a clear
-        # message before any downstream check (bin counts, surface method,
-        # Fourier-parameter sizing) can mask it.
         if len(self.ag) == 0:
             raise ValueError('Invalid selection. Empty AtomGroup.')
         validate_positive_bin_counts(n_x_bins, n_y_bins)
         self.n_x_bins = n_x_bins
         self.n_y_bins = n_y_bins
+        self._x_range_user = x_range is not None
+        self._y_range_user = y_range is not None
         self.x_range = x_range if x_range else (0, universe.dimensions[0])
         self.y_range = y_range if y_range else (0, universe.dimensions[1])
         self.dx = (self.x_range[1] - self.x_range[0]) / n_x_bins
@@ -269,21 +292,27 @@ class MembraneCurvature(AnalysisBase):
             self.edge_pad_bins = None
         self._pad_spec = None
 
-        valid_methods = ('binning', 'fourier')
-        if surface_method not in valid_methods:
-            raise ValueError(f'surface_method must be one of {valid_methods}, got {surface_method!r}')
-        self.surface_method = surface_method
+        try:
+            self.surface_method = self.SurfaceMethod(surface_method)
+        except ValueError as err:
+            allowed = ', '.join(repr(method.value) for method in self.SurfaceMethod)
+            raise ValueError(f'surface_method must be one of ({allowed}), got {surface_method!r}') from err
+        self.grid_origin = grid_origin
+        if grid_origin not in {'box', 'lipid_bbox'}:
+            raise ValueError("grid_origin must be 'box' or 'lipid_bbox'")
         self.fourier_m = int(fourier_m)
         self.fourier_n = int(fourier_n)
         self.fourier_rcond = fourier_rcond
 
-        if self.surface_method == 'fourier':
+        if self.surface_method == self.SurfaceMethod.FOURIER:
             if wrap is True:
                 raise ValueError("wrap=True is only valid when surface_method='binning'")
             if isinstance(fft_filter, dict):
-                raise ValueError("fft_filter dict is only allowed when surface_method='binning'")
+                raise ValueError('fft_filter dict is only allowed for binning surface methods')
             if self.padding:
-                raise ValueError("padding=True is only valid when surface_method='binning'")
+                raise ValueError(
+                    "padding=True is only valid for surface_method='binning' or surface_method='binning_nearest'"
+                )
             self.wrap = False
             self.fft_filter = None
             self._fft_q_bounds = None
@@ -301,6 +330,24 @@ class MembraneCurvature(AnalysisBase):
                     f'(fourier_m={self.fourier_m}, fourier_n={self.fourier_n}), got {n_atom}. '
                     f'Suggested max modes for {n_atom} atoms is '
                     f'fourier_m = fourier_n = {max_square_mode}.'
+                )
+        elif self.surface_method == self.SurfaceMethod.BINNING_NEAREST:
+            if wrap is True:
+                raise ValueError("wrap=True is not valid when surface_method='binning_nearest'")
+            if grid_origin == 'lipid_bbox' and fft_filter is not None:
+                raise ValueError("grid_origin='lipid_bbox' cannot be combined with fft_filter")
+            if grid_origin == 'lipid_bbox' and self.padding:
+                raise ValueError("grid_origin='lipid_bbox' cannot be combined with padding")
+            if self.padding:
+                validate_orthorhombic(universe.dimensions)
+            self.wrap = False
+            self.fft_filter = fft_filter
+            self._fft_q_bounds = None
+            if self.fft_filter is not None:
+                self._fft_q_bounds = resolve_fft_filter(self.fft_filter, self.dx, self.dy)
+                logger.info(
+                    f'fft_filter={self.fft_filter!r} resolved to '
+                    f'q_low={self._fft_q_bounds[0]:.6g}, q_high={self._fft_q_bounds[1]:.6g} (rad/A)',
                 )
         else:
             self.wrap = True if wrap is None else wrap
@@ -335,7 +382,8 @@ class MembraneCurvature(AnalysisBase):
                 warnings.warn(msg)
                 logger.warning(msg)
 
-        if not self.wrap and self.surface_method == 'binning' and not self.padding:
+        # Warn when binning without wrapping coordinates
+        if not self.wrap and self.surface_method == self.SurfaceMethod.BINNING and not self.padding:
             # Warning
             msg = (
                 ' `wrap == False` may result in inaccurate calculation '
@@ -362,7 +410,7 @@ class MembraneCurvature(AnalysisBase):
         self.results.gaussian = np.full((self.n_frames, self.n_x_bins, self.n_y_bins), np.nan)
 
     def _single_frame(self):
-        if self.surface_method == 'binning':
+        if self.surface_method == self.SurfaceMethod.BINNING:
             if self.wrap:
                 self._wrap_xy()
             if not self.padding:
@@ -389,6 +437,37 @@ class MembraneCurvature(AnalysisBase):
                 self.results.z_surface[self._frame_index] = z_surface
                 self.results.mean[self._frame_index] = mean_c
                 self.results.gaussian[self._frame_index] = gauss_c
+        elif self.surface_method == self.SurfaceMethod.BINNING_NEAREST:
+            box = self._ts.dimensions.copy()
+            if self._x_range_user or self.grid_origin == 'box':
+                x_range = self.x_range
+            else:
+                x_range = None
+            if self._y_range_user or self.grid_origin == 'box':
+                y_range = self.y_range
+            else:
+                y_range = None
+            z_surface, grid_axes = get_z_surface_nearest(
+                self.ag,
+                n_x_bins=self.n_x_bins,
+                n_y_bins=self.n_y_bins,
+                box=box,
+                grid_origin=self.grid_origin,
+                x_range=x_range,
+                y_range=y_range,
+            )
+            frame_dx = grid_axes['dx']
+            frame_dy = grid_axes['dy']
+            self.results.z_surface[self._frame_index] = z_surface
+            if self.padding:
+                _, mean_c, gauss_c = curvature_from_primary_with_edge_pad(
+                    z_surface, frame_dx, frame_dy, self.edge_pad_bins
+                )
+                self.results.mean[self._frame_index] = mean_c
+                self.results.gaussian[self._frame_index] = gauss_c
+            else:
+                self.results.mean[self._frame_index] = mean_curvature(z_surface, frame_dx, frame_dy)
+                self.results.gaussian[self._frame_index] = gaussian_curvature(z_surface, frame_dx, frame_dy)
         else:
             z_f, mean_f, gauss_f = fourier_curvature(
                 self.ag.positions,
@@ -406,8 +485,8 @@ class MembraneCurvature(AnalysisBase):
 
     def _conclude(self):
         z_average = np.nanmean(self.results.z_surface, axis=0)
-        # resolve bounds and apply filter ONLY when binning + filtering is enabled
-        if self.surface_method == 'binning' and self._fft_q_bounds is not None:
+        # apply filter when enabled
+        if self._fft_q_bounds is not None:
             self.results.average_z_surface = apply_fft_filter(z_average, self.dx, self.dy, self._fft_q_bounds)
             z_filtered = self.results.average_z_surface
             if self.padding:

--- a/membrane_curvature/binning_nearest_surface.py
+++ b/membrane_curvature/binning_nearest_surface.py
@@ -7,19 +7,32 @@ Binning Nearest Surface
 .. versionadded:: 2.0.0
 
 With ``surface_method='binning_nearest'``, :class:`~membrane_curvature.base.MembraneCurvature`
-derives a surface by assigning each grid point the ``z`` of the nearest lipid in
+builds a grid to derive a surface by assigning each grid point the ``z`` of the nearest lipid in
 the ``xy`` plane following the minimum-image convention. Grid points sit at bin corners
-(``left + i * bin_size``), following the nearest-lipid assignment in g_lomepro
-[CAG2009]_.
+(``left + i * bin_size``). This is the same algorithm used in `g_lomepro`_ to derive surfaces
+from lipid centers as described in [CAG2009]_.
 
 This height field is then used to calculate mean and Gaussian curvature using
 finite differences.
 
+Note that this method is different from the ``binning`` and ``fourier`` methods, which evaluate
+the surface on bin centres. For the same bin counts and box extent, the ``binning_nearest``
+method's maps are offset by half a bin relative to the ``binning`` and ``fourier`` methods.
+
 .. [CAG2009] Vytautas Gapsys, Bert L. de Groot, Rodolfo Briones,
     *Computational analysis of local membrane properties*,
-    Journal of Computer-Aided Molecular Design (2013), doi: `doi:10.1007/s10822-013-9684-0`_.
+    Journal of Computer-Aided Molecular Design (2013), doi: `10.1007/s10822-013-9684-0`_.
 
 .. _`10.1007/s10822-013-9684-0`: https://doi.org/10.1007/s10822-013-9684-0
+
+.. _g_lomepro: https://github.com/vgapsys/g_lomepro
+
+.. warning::
+
+    Running with ``surface_method='binning_nearest'`` does NOT mean that
+    :class:`~membrane_curvature.base.MembraneCurvature` reproduces the results from `g_lomepro`_.
+    The ``binning_nearest`` method reproduces the grid construction and nearest-lipid assignment
+    as implemented in [CAG2009]_.
 
 .. note::
 
@@ -27,13 +40,6 @@ finite differences.
     high-frequency noise from the height field. The filter is applied to the
     height field before calculating curvature. For more details, check the API
     documentation for the :ref:`fft_filtering` module.
-
-
-.. warning::
-
-    ``binning`` and ``fourier`` evaluate the surface on bin centres, so for the
-    same bin counts and box extent their maps are offset by half a bin relative
-    to ``binning_nearest``.
 
 Functions
 ---------

--- a/membrane_curvature/binning_nearest_surface.py
+++ b/membrane_curvature/binning_nearest_surface.py
@@ -1,0 +1,179 @@
+r"""
+
+----------------------------
+Binning Nearest Surface
+----------------------------
+
+.. versionadded:: 2.0.0
+
+With ``surface_method='binning_nearest'``, :class:`~membrane_curvature.base.MembraneCurvature`
+derives a surface by assigning each grid point the ``z`` of the nearest lipid in
+the ``xy`` plane following the minimum-image convention. Grid points sit at bin corners
+(``left + i * bin_size``), following the nearest-lipid assignment in g_lomepro
+[CAG2009]_.
+
+This height field is then used to calculate mean and Gaussian curvature using
+finite differences.
+
+.. [CAG2009] Vytautas Gapsys, Bert L. de Groot, Rodolfo Briones,
+    *Computational analysis of local membrane properties*,
+    Journal of Computer-Aided Molecular Design (2013), doi: `doi:10.1007/s10822-013-9684-0`_.
+
+.. _`10.1007/s10822-013-9684-0`: https://doi.org/10.1007/s10822-013-9684-0
+
+.. note::
+
+    The binning nearest method supports a brick-wall filter to remove
+    high-frequency noise from the height field. The filter is applied to the
+    height field before calculating curvature. For more details, check the API
+    documentation for the :ref:`fft_filtering` module.
+
+
+.. warning::
+
+    ``binning`` and ``fourier`` evaluate the surface on bin centres, so for the
+    same bin counts and box extent their maps are offset by half a bin relative
+    to ``binning_nearest``.
+
+Functions
+---------
+"""
+
+import MDAnalysis.lib.distances as mda_distances
+import numpy as np
+from MDAnalysis.exceptions import NoDataError
+
+
+def lipid_center_positions(atomgroup):
+    """
+    One reference point per lipid: the center of the **selected** atoms in each
+    residue.
+
+    .. note::
+
+        Only atoms in ``atomgroup`` contribute. Same selection as the surface method,
+        not the full residue. For a one-atom reference such as ``name PO4`` the point is
+        that bead's position. This is the same reference used by the ``binning`` and
+        ``fourier`` surface methods. When several atoms per residue are selected they
+        are reduced to their mass weighted center. Geometric center when masses are
+        unavailable or all zero.
+
+    Parameters
+    ----------
+    atomgroup : MDAnalysis.core.groups.AtomGroup
+        AtomGroup of reference selection (one leaflet) that defines the surface.
+
+    Returns
+    -------
+    centers : numpy.ndarray
+        One ``(x, y, z)`` reference point per residue, shape ``(n_residues, 3)``.
+    """
+    try:
+        masses = atomgroup.masses
+    except (NoDataError, AttributeError):
+        masses = None
+    if masses is not None and np.any(masses != 0):
+        return atomgroup.center_of_mass(compound='residues')
+    return atomgroup.center_of_geometry(compound='residues')
+
+
+def _grid_extent_from_box(box, grid_origin, lipid_centers):
+    """Return (left_x, left_y, right_x, right_y) for the bin grid."""
+    left_x, left_y = 0.0, 0.0
+    right_x, right_y = float(box[0]), float(box[1])
+    if grid_origin == 'lipid_bbox':
+        left_x = float(np.min(lipid_centers[:, 0]))
+        left_y = float(np.min(lipid_centers[:, 1]))
+        right_x = float(np.max(lipid_centers[:, 0]))
+        right_y = float(np.max(lipid_centers[:, 1]))
+    return left_x, left_y, right_x, right_y
+
+
+def _bin_corner_grid(left_x, left_y, bin_sizex, bin_sizey, n_x_bins, n_y_bins):
+    """Bin reference points at lower-left corners."""
+    x_corners = left_x + np.arange(n_x_bins, dtype=float) * bin_sizex
+    y_corners = left_y + np.arange(n_y_bins, dtype=float) * bin_sizey
+    x_grid, y_grid = np.meshgrid(x_corners, y_corners, indexing='ij')
+    refs_xy = np.column_stack([x_grid.ravel(), y_grid.ravel(), np.zeros(x_grid.size)])
+    return refs_xy, x_grid.shape
+
+
+def _nearest_grid_axes(box, grid_origin, lipid_centers, n_x_bins, n_y_bins, x_range, y_range):
+    """Return grid origin and bin widths for the nearest-neighbor surface."""
+    left_x, left_y, right_x, right_y = _grid_extent_from_box(box, grid_origin, lipid_centers)
+    if x_range is not None:
+        left_x, right_x = x_range
+    if y_range is not None:
+        left_y, right_y = y_range
+    bin_sizex = (right_x - left_x) / n_x_bins
+    bin_sizey = (right_y - left_y) / n_y_bins
+    return left_x, left_y, bin_sizex, bin_sizey
+
+
+def _z_surface_from_nearest(refs_xy, lipid_centers, box, grid_shape):
+    """Assign each grid point the ``z`` of the nearest lipid in the ``xy`` plane."""
+    lipid_xy = lipid_centers.copy()
+    lipid_xy[:, 2] = 0.0
+    distances = mda_distances.distance_array(refs_xy, lipid_xy, box=box)
+    nearest_index = np.argmin(distances, axis=1)
+    return lipid_centers[nearest_index, 2].reshape(grid_shape)
+
+
+def get_z_surface_nearest(
+    atomgroup,
+    n_x_bins=10,
+    n_y_bins=10,
+    box=None,
+    grid_origin='box',
+    x_range=None,
+    y_range=None,
+):
+    """
+    Derive surface by assigning each grid corner the ``z`` of the nearest lipid in ``xy``.
+
+    The atomgroup should contain reference atoms for a single leaflet. The height
+    field is sampled at bin corners (``left + i * bin_size``), not bin centres.
+    Minimum-image distances use :func:`~MDAnalysis.lib.distances.distance_array`.
+
+    Parameters
+    ----------
+    atomgroup : MDAnalysis.core.groups.AtomGroup
+        Reference atoms for one leaflet (typically one atom per lipid).
+    n_x_bins : int
+        Number of bins along ``x``.
+    n_y_bins : int
+        Number of bins along ``y``.
+    box : array-like, optional
+        Unit cell in MDAnalysis format ``[lx, ly, lz, alpha, beta, gamma]``.
+        Required for periodic minimum-image distances.
+    grid_origin : {'box', 'lipid_bbox'}
+        How to set the xy grid extent. ``box`` uses ``[0, lx]`` and ``[0, ly]``.
+    x_range : tuple of (float, float), optional
+        Override grid extent along ``x`` as ``(left_x, right_x)``.
+    y_range : tuple of (float, float), optional
+        Override grid extent along ``y`` as ``(left_y, right_y)``.
+
+    Returns
+    -------
+    z_surface : numpy.ndarray
+        Height field of shape ``(n_x_bins, n_y_bins)``.
+    grid_axes : dict
+        Per-frame grid metadata: ``left_x``, ``left_y``, ``dx``, ``dy``.
+    """
+    if box is None:
+        raise ValueError('box is required for minimum-image distances')
+
+    lipid_centers = lipid_center_positions(atomgroup)
+    left_x, left_y, bin_sizex, bin_sizey = _nearest_grid_axes(
+        box, grid_origin, lipid_centers, n_x_bins, n_y_bins, x_range, y_range
+    )
+    refs_xy, grid_shape = _bin_corner_grid(left_x, left_y, bin_sizex, bin_sizey, n_x_bins, n_y_bins)
+    z_surface = _z_surface_from_nearest(refs_xy, lipid_centers, box, grid_shape)
+
+    grid_axes = {
+        'left_x': left_x,
+        'left_y': left_y,
+        'dx': bin_sizex,
+        'dy': bin_sizey,
+    }
+    return z_surface, grid_axes

--- a/membrane_curvature/tests/test_binning_nearest.py
+++ b/membrane_curvature/tests/test_binning_nearest.py
@@ -1,0 +1,177 @@
+"""Unit tests for binning nearest-neighbor surface functions."""
+
+import MDAnalysis as mda
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from membrane_curvature.base import MembraneCurvature
+from membrane_curvature.binning_nearest_surface import get_z_surface_nearest, lipid_center_positions
+
+
+@pytest.fixture
+def box_100():
+    return np.array([100.0, 100.0, 100.0, 90.0, 90.0, 90.0])
+
+
+@pytest.fixture
+def grid_2x2():
+    return dict(n_x_bins=2, n_y_bins=2)
+
+
+@pytest.fixture
+def bilayer_universe(box_100):
+    """Two single-bead lipids: upper at (90, 10, 80), lower at (10, 10, 20)."""
+    universe = mda.Universe.empty(
+        2,
+        trajectory=True,
+        n_residues=2,
+        atom_resindex=[0, 1],
+        residue_segindex=[0, 0],
+    )
+    universe.atoms.positions = np.array([[90.0, 10.0, 80.0], [10.0, 10.0, 20.0]])
+    universe.dimensions = box_100
+    universe.trajectory[0]
+    return universe
+
+
+@pytest.fixture
+def xy_nearest_universe():
+    """Lipid at (5, 5, 105) is xy-nearest to corner (0, 0), not (30, 30, 96)."""
+    universe = mda.Universe.empty(
+        2,
+        trajectory=True,
+        n_residues=2,
+        atom_resindex=[0, 1],
+        residue_segindex=[0, 0],
+    )
+    universe.atoms.positions = np.array([[5.0, 5.0, 105.0], [30.0, 30.0, 96.0]])
+    universe.dimensions = np.array([100.0, 100.0, 233.0, 90.0, 90.0, 90.0])
+    universe.trajectory[0]
+    return universe
+
+
+@pytest.fixture
+def two_bead_residue_universe(box_100):
+    """One residue with two atoms for mass-weighted center tests."""
+    universe = mda.Universe.empty(
+        2,
+        trajectory=True,
+        n_residues=1,
+        atom_resindex=[0, 0],
+        residue_segindex=[0],
+    )
+    universe.atoms.positions = np.array([[0.0, 0.0, 0.0], [10.0, 0.0, 10.0]])
+    universe.add_TopologyAttr('masses')
+    universe.atoms[0].mass = 1.0
+    universe.atoms[1].mass = 3.0
+    universe.dimensions = box_100
+    return universe
+
+
+@pytest.fixture
+def nearest_surface(box_100, grid_2x2):
+    def _call(atoms, *, box=None, grid_origin='box', x_range=None, y_range=None):
+        return get_z_surface_nearest(
+            atoms,
+            box=box_100 if box is None else box,
+            grid_origin=grid_origin,
+            x_range=x_range,
+            y_range=y_range,
+            **grid_2x2,
+        )
+
+    return _call
+
+
+def test_get_z_surface_nearest_upper_leaflet_mic(bilayer_universe, nearest_surface):
+    # Lipid at x=90 wraps to corner (0, 0) under minimum-image.
+    z_surface, grid_axes = nearest_surface(bilayer_universe.atoms[[0]])
+    assert_allclose(z_surface[0, 0], 80.0)
+    assert_allclose(z_surface[1, 1], 80.0)
+    assert_allclose(grid_axes['dx'], 50.0)
+    assert_allclose(grid_axes['dy'], 50.0)
+
+
+def test_get_z_surface_nearest_lower_leaflet(bilayer_universe, nearest_surface):
+    z_surface, _ = nearest_surface(bilayer_universe.atoms[[1]])
+    assert_allclose(z_surface[0, 0], 20.0)
+
+
+def test_get_z_surface_nearest_uses_xy_distance_only(xy_nearest_universe, nearest_surface):
+    z_surface, _ = nearest_surface(xy_nearest_universe.atoms)
+    assert_allclose(z_surface[0, 0], 105.0)
+
+
+def test_get_z_surface_nearest_requires_box(bilayer_universe, grid_2x2):
+    with pytest.raises(ValueError, match='box is required'):
+        get_z_surface_nearest(bilayer_universe.atoms[[0]], box=None, **grid_2x2)
+
+
+def test_get_z_surface_nearest_range_override(bilayer_universe, nearest_surface):
+    _, grid_axes = nearest_surface(
+        bilayer_universe.atoms[[0]],
+        x_range=(10.0, 90.0),
+        y_range=(20.0, 80.0),
+    )
+    assert_allclose(grid_axes['dx'], 40.0)
+    assert_allclose(grid_axes['dy'], 30.0)
+
+
+@pytest.mark.parametrize(
+    'masses, expected',
+    [
+        ([1.0, 3.0], [[7.5, 0.0, 7.5]]),  # mass-weighted center of residue
+        ([0.0, 0.0], [[5.0, 0.0, 5.0]]),  # all-zero masses -> geometric center
+    ],
+)
+def test_lipid_center_positions(two_bead_residue_universe, masses, expected):
+    two_bead_residue_universe.atoms.masses = masses
+    assert_allclose(lipid_center_positions(two_bead_residue_universe.atoms), expected)
+
+
+def test_lipid_center_positions_without_masses(bilayer_universe):
+    centers = lipid_center_positions(bilayer_universe.atoms[[0]])
+    assert_allclose(centers, bilayer_universe.atoms[[0]].positions)
+
+
+def test_membrane_curvature_binning_nearest_runs(bilayer_universe, grid_2x2):
+    mc = MembraneCurvature(
+        bilayer_universe,
+        select='index 0',
+        surface_method='binning_nearest',
+        grid_origin='box',
+        fft_filter=None,
+        **grid_2x2,
+    ).run()
+    assert mc.results.z_surface.shape == (1, 2, 2)
+    assert_allclose(mc.results.z_surface[0, 0, 0], 80.0)
+
+
+@pytest.mark.parametrize(
+    'kwargs, match',
+    [
+        (dict(wrap=True), r"wrap=True is not valid when surface_method='binning_nearest'"),
+        (
+            dict(select='index 0', grid_origin='lipid_bbox', fft_filter='auto'),
+            r"grid_origin='lipid_bbox' cannot be combined with fft_filter",
+        ),
+        (dict(grid_origin='invalid'), r"grid_origin must be 'box' or 'lipid_bbox'"),
+    ],
+)
+def test_membrane_curvature_binning_nearest_raises(bilayer_universe, kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        MembraneCurvature(bilayer_universe, surface_method='binning_nearest', **kwargs)
+
+
+def test_membrane_curvature_binning_nearest_resolves_fft_filter(bilayer_universe, grid_2x2):
+    mc = MembraneCurvature(
+        bilayer_universe,
+        select='index 0',
+        surface_method='binning_nearest',
+        grid_origin='box',
+        fft_filter='auto',
+        **grid_2x2,
+    )
+    assert mc._fft_q_bounds is not None
+    assert mc._fft_q_bounds[0] == 0.0

--- a/membrane_curvature/tests/test_binning_nearest.py
+++ b/membrane_curvature/tests/test_binning_nearest.py
@@ -85,7 +85,6 @@ def nearest_surface(box_100, grid_2x2):
 
 
 def test_get_z_surface_nearest_upper_leaflet_mic(bilayer_universe, nearest_surface):
-    # Lipid at x=90 wraps to corner (0, 0) under minimum-image.
     z_surface, grid_axes = nearest_surface(bilayer_universe.atoms[[0]])
     assert_allclose(z_surface[0, 0], 80.0)
     assert_allclose(z_surface[1, 1], 80.0)
@@ -94,12 +93,12 @@ def test_get_z_surface_nearest_upper_leaflet_mic(bilayer_universe, nearest_surfa
 
 
 def test_get_z_surface_nearest_lower_leaflet(bilayer_universe, nearest_surface):
-    z_surface, _ = nearest_surface(bilayer_universe.atoms[[1]])
+    z_surface, _grid_axes = nearest_surface(bilayer_universe.atoms[[1]])
     assert_allclose(z_surface[0, 0], 20.0)
 
 
 def test_get_z_surface_nearest_uses_xy_distance_only(xy_nearest_universe, nearest_surface):
-    z_surface, _ = nearest_surface(xy_nearest_universe.atoms)
+    z_surface, _grid_axes = nearest_surface(xy_nearest_universe.atoms)
     assert_allclose(z_surface[0, 0], 105.0)
 
 
@@ -109,13 +108,21 @@ def test_get_z_surface_nearest_requires_box(bilayer_universe, grid_2x2):
 
 
 def test_get_z_surface_nearest_range_override(bilayer_universe, nearest_surface):
-    _, grid_axes = nearest_surface(
+    _z_surface, grid_axes = nearest_surface(
         bilayer_universe.atoms[[0]],
         x_range=(10.0, 90.0),
         y_range=(20.0, 80.0),
     )
     assert_allclose(grid_axes['dx'], 40.0)
     assert_allclose(grid_axes['dy'], 30.0)
+
+
+def test_get_z_surface_nearest_lipid_bbox_extent(xy_nearest_universe, nearest_surface):
+    _z_surface, grid_axes = nearest_surface(xy_nearest_universe.atoms, grid_origin='lipid_bbox')
+    assert_allclose(grid_axes['left_x'], 5.0)
+    assert_allclose(grid_axes['left_y'], 5.0)
+    assert_allclose(grid_axes['dx'], 12.5)
+    assert_allclose(grid_axes['dy'], 12.5)
 
 
 @pytest.mark.parametrize(
@@ -156,6 +163,10 @@ def test_membrane_curvature_binning_nearest_runs(bilayer_universe, grid_2x2):
             dict(select='index 0', grid_origin='lipid_bbox', fft_filter='auto'),
             r"grid_origin='lipid_bbox' cannot be combined with fft_filter",
         ),
+        (
+            dict(select='index 0', grid_origin='lipid_bbox', padding=True),
+            r"grid_origin='lipid_bbox' cannot be combined with padding",
+        ),
         (dict(grid_origin='invalid'), r"grid_origin must be 'box' or 'lipid_bbox'"),
     ],
 )
@@ -175,3 +186,35 @@ def test_membrane_curvature_binning_nearest_resolves_fft_filter(bilayer_universe
     )
     assert mc._fft_q_bounds is not None
     assert mc._fft_q_bounds[0] == 0.0
+
+
+def test_membrane_curvature_binning_nearest_with_padding(bilayer_universe, grid_2x2):
+    mc = MembraneCurvature(
+        bilayer_universe,
+        select='index 0',
+        surface_method='binning_nearest',
+        grid_origin='box',
+        fft_filter=None,
+        padding=True,
+        edge_pad_bins=1,
+        **grid_2x2,
+    ).run()
+    assert mc.padding is True
+    assert mc.results.z_surface.shape == (1, 2, 2)
+    assert mc.results.mean.shape == (1, 2, 2)
+    assert mc.results.gaussian.shape == (1, 2, 2)
+    assert np.any(np.isfinite(mc.results.mean))
+
+
+def test_membrane_curvature_binning_nearest_lipid_bbox_runs(xy_nearest_universe, grid_2x2):
+    mc = MembraneCurvature(
+        xy_nearest_universe,
+        select='all',
+        surface_method='binning_nearest',
+        grid_origin='lipid_bbox',
+        fft_filter=None,
+        **grid_2x2,
+    ).run()
+    assert mc.results.z_surface.shape == (1, 2, 2)
+    assert np.all(np.isfinite(mc.results.z_surface))
+    assert np.all(np.isfinite(mc.results.mean))

--- a/membrane_curvature/tests/test_membrane_curvature.py
+++ b/membrane_curvature/tests/test_membrane_curvature.py
@@ -1422,7 +1422,10 @@ class TestMembraneCurvature(object):
         assert mc._pad_spec['n_y_bins_pad'] == 7
 
     def test_padding_true_rejected_fourier(self, universe_fourier_defaults):
-        with pytest.raises(ValueError, match=r"padding=True is only valid when surface_method='binning'"):
+        with pytest.raises(
+            ValueError,
+            match=r"padding=True is only valid when surface_method='binning' | surface_method='binning_nearest'",
+        ):
             MembraneCurvature(universe_fourier_defaults, padding=True)
 
     def test_padding_rejects_non_orthorhombic_box(self, universe_dummy_full):


### PR DESCRIPTION
<!--
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->

## Description
<!--
Provide a brief description of the PR's purpose here.
-->
Implement new surface method `'binning_nearest'` that derive the leaflet height field by assigning each grid corner the `z` of the nearest lipid in the `xy` plane.

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use a bullet list. -->
- Integrated `biining_nearest` with new `SurfaceMethod` enum, including optional periodic edge `padding`, brick-wall `fft_filter`, and `grid_origin`.
- Document in API docs.

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [N/A] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] `CHANGELOG` file updated?
