### PR TITLE
feat: Introduce `curvature_average` parameter for curvature computati…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@ Membranecurvature CHANGELOG
 
 ---
 
+* Added ``curvature_average`` parameter to choose between time-averaged per-frame
+  curvatures (``'per_frame'``, default) and curvature of the time-averaged surface
+  (``'surface'``)
 * Added ``surface_method='binning_nearest'`` as a new surface method (PR #246)
 * Feature: Added periodic edge padding for the binning surface method (PR #238)
 * Refactored binning surface method to use ``np.add.at`` for improved performance (PR #240)

--- a/docs/source/pages/Algorithm.rst
+++ b/docs/source/pages/Algorithm.rst
@@ -658,10 +658,40 @@ After the trajectory is processed, MembraneCurvature stores the averaged maps in
 :attr:`MembraneCurvature.results.average_gaussian` arrays, respectively.
 Each array has shape ``(n_x_bins, n_y_bins)``.
 
-How those averages are built depends on ``fft_filter``:
+4.1 Curvature averaging modes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Curvature is a **nonlinear** function of the height field, so the time
+average of per-frame curvatures :math:`\langle H \rangle` is in general
+**not** equal to the curvature evaluated on the time-averaged surface
+:math:`H(\langle S \rangle)`:
+
+.. math:: \langle H \rangle \neq H(\langle S \rangle)
+
+The ``curvature_average`` parameter controls which quantity is stored in
+``results.average_mean`` and ``results.average_gaussian``:
+
+- ``curvature_average='per_frame'`` (default):
+  :math:`\langle H \rangle` — the time average of the per-frame curvature
+  arrays.  This preserves the contribution of instantaneous thermal
+  fluctuations.  When ``fft_filter`` is also active, backward-compatible
+  behaviour computes curvature from the filtered average height instead.
+
+- ``curvature_average='surface'``:
+  :math:`H(\langle S \rangle)` — curvature evaluated on the time-averaged
+  (and optionally FFT-filtered) surface.  By averaging the height field
+  first, thermal fluctuations that cancel over the trajectory are suppressed
+  before curvature is evaluated.
+
+4.2 Interaction with ``fft_filter``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+How those averages are built also depends on ``fft_filter``:
 
 - With the default ``fft_filter=None``, the average maps are time averages of the
-  per-frame arrays ``z_surface``, ``mean``, and ``gaussian``.
+  per-frame arrays ``z_surface``, ``mean``, and ``gaussian`` (when
+  ``curvature_average='per_frame'``), or curvature of the average surface
+  (when ``curvature_average='surface'``).
 - With ``fft_filter`` enabled (``'auto'`` or a manual ``{'q': ...}`` dict),
   MembraneCurvature first time-averages ``z_surface``, applies one brick-wall
   filter to that average, and then computes ``average_mean`` and

--- a/docs/source/pages/Usage.rst
+++ b/docs/source/pages/Usage.rst
@@ -330,6 +330,53 @@ passing a tuple of ``(q_low, q_high)`` in rad/Å to ``fft_filter={'q': (q_low, q
   When using the brick-wall filter, the recommended way is to use the automatic mode
   ``fft_filter='auto'`` with the default low-pass ``(0, 0.5 * q_Nyq)`` from ``dx`` and ``dy``.
 
+.. _curvature-averaging:
+
+2.1.3 Curvature averaging modes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, :attr:`results.average_mean` and :attr:`results.average_gaussian`
+store the time average of per-frame curvatures :math:`\langle H \rangle`.
+Because curvature is a nonlinear function of the height field,
+:math:`\langle H \rangle \neq H(\langle S \rangle)` in general.
+
+The ``curvature_average`` parameter lets you choose which quantity to compute:
+
+- ``curvature_average='per_frame'`` (default): :math:`\langle H \rangle` —
+  the time average of instantaneous curvature maps.
+- ``curvature_average='surface'``: :math:`H(\langle S \rangle)` —
+  curvature evaluated on the time-averaged surface. This suppresses thermal
+  fluctuations that cancel in height but survive in per-frame curvature.
+
+.. code-block:: python
+
+    # Average the curvature computed for each frame.
+    mc_fluct = MembraneCurvature(universe,
+                                 select='name PO4',
+                                 surface_method='binning',
+                                 curvature_average='per_frame').run()
+
+    H_avg = mc_fluct.results.average_mean
+
+    # Compute the curvature of the time-averaged membrane surface.
+    mc_shape = MembraneCurvature(universe,
+                                 select='name PO4',
+                                 surface_method='binning',
+                                 curvature_average='surface').run()
+
+    H_of_avg_surface = mc_shape.results.average_mean
+
+.. note::
+
+   Users can also compute :math:`H(\langle S \rangle)` manually::
+
+       from membrane_curvature.curvature import mean_curvature
+       H_of_S = mean_curvature(mc.results.average_z_surface, mc.dx, mc.dy)
+
+   The ``curvature_average='surface'`` option provides a convenient shortcut
+   that additionally handles ``padding`` and ``fft_filter`` correctly.
+
+
 .. _membrane-protein:
 
 2.2 Membrane-protein systems

--- a/membrane_curvature/base.py
+++ b/membrane_curvature/base.py
@@ -125,6 +125,27 @@ class MembraneCurvature(AnalysisBase):
     edge_pad_bins : int, optional
         Buffer width in bins on each side when ``padding=True`` (default ``2``).
         Ignored when ``padding=False``.
+    curvature_average : {'per_frame', 'surface'}, optional
+        Controls how :attr:`results.average_mean` and
+        :attr:`results.average_gaussian` are built after the trajectory
+        is processed (default ``'per_frame'``).
+
+        ``'per_frame'``
+            :math:`\langle H \rangle` — time average of the per-frame
+            curvature arrays.  This is the default and preserves backward
+            compatibility.  When ``fft_filter`` is also enabled, the average
+            curvatures are computed from the filtered average surface
+            :math:`H(\langle S \rangle_{\mathrm{filtered}})` instead, to
+            retain the established FFT-filter workflow.
+        ``'surface'``
+            :math:`H(\langle S \rangle)` — curvature evaluated on the
+            time-averaged (and optionally FFT-filtered) surface.  This
+            suppresses the contribution of instantaneous thermal
+            fluctuations that would otherwise survive in
+            :math:`\langle H \rangle`.
+
+        Because curvature is a **nonlinear** function of the height field,
+        :math:`\langle H \rangle \neq H(\langle S \rangle)` in general.
 
     Attributes
     ----------
@@ -139,20 +160,24 @@ class MembraneCurvature(AnalysisBase):
         Per-frame Gaussian curvature associated with the surface.
         Array of shape (`n_frames`, `n_x_bins`, `n_y_bins`)
     results.average_z_surface : ndarray
-        Average of the array elements in `z_surface`. With ``binning`` or
-        ``binning_nearest`` and ``fft_filter`` enabled, this is the FFT-filtered
-        temporal mean of ``z_surface``, not the mean of per-frame filtered surfaces.
-        Each array has shape (`n_x_bins`, `n_y_bins`)
+        Time-averaged height surface.  With ``fft_filter`` enabled on binning
+        methods, this is the FFT-filtered temporal mean of ``z_surface``.
+        Shape (`n_x_bins`, `n_y_bins`).
     results.average_mean : ndarray
-        Average of the array elements in `mean_curvature`. With ``binning`` or
-        ``binning_nearest`` and ``fft_filter`` enabled, curvature of the filtered
-        time-averaged height (not the time average of per-frame ``results.mean``).
-        Each array has shape (`n_x_bins`, `n_y_bins`)
+        Averaged mean curvature map.  The semantics depend on
+        ``curvature_average``:
+
+        * ``'per_frame'`` (default, no ``fft_filter``): time average of
+          per-frame curvatures, :math:`\langle H \rangle`.
+        * ``'surface'`` (or ``'per_frame'`` with ``fft_filter``): mean
+          curvature of the (optionally filtered) average surface,
+          :math:`H(\langle S \rangle)`.
+
+        Shape (`n_x_bins`, `n_y_bins`).
     results.average_gaussian : ndarray
-        Average of the array elements in `gaussian_curvature`. With ``binning`` or
-        ``binning_nearest`` and ``fft_filter`` enabled, curvature of the filtered
-        time-averaged height (not the time average of per-frame ``results.gaussian``).
-        Each array has shape (`n_x_bins`, `n_y_bins`)
+        Averaged Gaussian curvature map.  Same semantics as
+        ``results.average_mean`` but for Gaussian curvature :math:`K`.
+        Shape (`n_x_bins`, `n_y_bins`).
 
     Raises
     ------
@@ -168,7 +193,8 @@ class MembraneCurvature(AnalysisBase):
         with ``surface_method='fourier'``, if ``padding=True`` with
         ``surface_method='fourier'``, if ``padding=True`` on a
         non-orthorhombic box, or if ``edge_pad_bins`` is not an integer
-        ``>= 1`` when ``padding=True``.
+        ``>= 1`` when ``padding=True``, or if ``curvature_average`` is
+        not ``'per_frame'`` or ``'surface'``.
 
     See also
     --------
@@ -213,9 +239,26 @@ class MembraneCurvature(AnalysisBase):
 
     The attributes :attr:`~MembraneCurvature.results.average_mean` and
     :attr:`~MembraneCurvature.results.average_gaussian` contain mean and
-    Gaussian curvature maps for analysis and plotting. With ``fft_filter`` on
-    binning surfaces they are curvatures of the filtered average height, not the
-    time average of per-frame curvatures.
+    Gaussian curvature maps for analysis and plotting.
+
+    **Curvature averaging modes**
+
+    The ``curvature_average`` parameter controls how the averaged curvature
+    maps are computed:
+
+    * ``curvature_average='per_frame'`` (default) stores the time average of
+      per-frame curvatures: :math:`\langle H \rangle`.  When ``fft_filter`` is
+      also active, backward-compatible behaviour applies curvature to the
+      filtered average height instead.
+    * ``curvature_average='surface'`` always evaluates curvature on the
+      time-averaged (and optionally FFT-filtered) surface:
+      :math:`H(\langle S \rangle)`.
+
+    Because curvature is nonlinear, :math:`\langle H \rangle \neq
+    H(\langle S \rangle)` in general.  The ``'surface'`` mode suppresses
+    contributions from instantaneous thermal fluctuations that cancel in
+    height over the trajectory but survive when curvature is averaged
+    per frame.
 
     Example
     -----------
@@ -231,6 +274,16 @@ class MembraneCurvature(AnalysisBase):
         mean_curvature =  mc.results.average_mean
         gaussian_curvature = mc.results.average_gaussian
 
+    To compute curvature on the time-averaged surface instead of
+    averaging per-frame curvatures, use ``curvature_average='surface'``::
+
+        mc_shape = MembraneCurvature(u,
+                                     select='name PO4',
+                                     curvature_average='surface').run()
+
+        # H(⟨S⟩) — curvature of the averaged surface
+        H_of_avg_surface = mc_shape.results.average_mean
+
     The respective 2D curvature plots can be obtained using the `matplotlib`
     package for data visualization via :func:`~matplotlib.pyplot.contourf` or
     :func:`~matplotlib.pyplot.imshow`.
@@ -242,6 +295,11 @@ class MembraneCurvature(AnalysisBase):
 
 
     """
+    class CurvatureAverage(StrEnum):
+        """Allowed values for ``curvature_average``."""
+
+        PER_FRAME = 'per_frame'
+        SURFACE = 'surface'
 
     class SurfaceMethod(StrEnum):
         """Allowed values for ``surface_method``."""
@@ -267,6 +325,7 @@ class MembraneCurvature(AnalysisBase):
         padding=False,
         edge_pad_bins=2,
         grid_origin='box',
+        curvature_average='per_frame',
         **kwargs,
     ):
 
@@ -297,13 +356,18 @@ class MembraneCurvature(AnalysisBase):
         except ValueError as err:
             allowed = ', '.join(repr(method.value) for method in self.SurfaceMethod)
             raise ValueError(f'surface_method must be one of ({allowed}), got {surface_method!r}') from err
+      
+        try:
+            self.curvature_average = self.CurvatureAverage(curvature_average)
+        except ValueError as err:
+            allowed = ', '.join(repr(method.value) for method in self.CurvatureAverage)
+            raise ValueError(f'curvature_average must be one of ({allowed}), got {curvature_average!r}') from err
         self.grid_origin = grid_origin
         if grid_origin not in {'box', 'lipid_bbox'}:
             raise ValueError("grid_origin must be 'box' or 'lipid_bbox'")
         self.fourier_m = int(fourier_m)
         self.fourier_n = int(fourier_n)
         self.fourier_rcond = fourier_rcond
-
         if self.surface_method == self.SurfaceMethod.FOURIER:
             if wrap is True:
                 raise ValueError("wrap=True is only valid when surface_method='binning'")
@@ -485,20 +549,36 @@ class MembraneCurvature(AnalysisBase):
 
     def _conclude(self):
         z_average = np.nanmean(self.results.z_surface, axis=0)
-        # apply filter when enabled
+
+        # Step 1: build average_z_surface (apply FFT filter when enabled)
         if self._fft_q_bounds is not None:
-            self.results.average_z_surface = apply_fft_filter(z_average, self.dx, self.dy, self._fft_q_bounds)
-            z_filtered = self.results.average_z_surface
+            self.results.average_z_surface = apply_fft_filter(
+                z_average, self.dx, self.dy, self._fft_q_bounds
+            )
+        else:
+            self.results.average_z_surface = z_average
+
+        # Step 2: compute average curvature maps
+        # 'surface' mode  → H(⟨S⟩): curvature of the (possibly filtered) average surface
+        # 'per_frame' mode → ⟨H⟩: time average of per-frame curvatures
+        #   (with fft_filter active, per_frame falls back to H(⟨S⟩) for backward compat)
+        use_surface_curvature = (
+            self.curvature_average == self.CurvatureAverage.SURFACE
+            or self._fft_q_bounds is not None
+        )
+
+        if use_surface_curvature:
+            z_for_curv = self.results.average_z_surface
             if self.padding:
                 _, avg_mean, avg_gauss = curvature_from_primary_with_edge_pad(
-                    z_filtered, self.dx, self.dy, self.edge_pad_bins
+                    z_for_curv, self.dx, self.dy, self.edge_pad_bins
                 )
                 self.results.average_mean = avg_mean
                 self.results.average_gaussian = avg_gauss
             else:
-                self.results.average_mean = mean_curvature(z_filtered, self.dx, self.dy)
-                self.results.average_gaussian = gaussian_curvature(z_filtered, self.dx, self.dy)
+                self.results.average_mean = mean_curvature(z_for_curv, self.dx, self.dy)
+                self.results.average_gaussian = gaussian_curvature(z_for_curv, self.dx, self.dy)
         else:
-            self.results.average_z_surface = z_average
+            # ⟨H⟩ — time average of per-frame curvatures
             self.results.average_mean = np.nanmean(self.results.mean, axis=0)
             self.results.average_gaussian = np.nanmean(self.results.gaussian, axis=0)

--- a/membrane_curvature/tests/test_membrane_curvature.py
+++ b/membrane_curvature/tests/test_membrane_curvature.py
@@ -1474,3 +1474,125 @@ class TestMembraneCurvature(object):
         assert mc.results.average_gaussian.shape == (3, 3)
         assert np.any(np.isfinite(mc.results.average_mean))
         assert np.any(np.isfinite(mc.results.average_gaussian))
+
+    # --- curvature_average ------------------------------------------------
+
+    def test_default_curvature_average_is_per_frame(self, universe_dummy_full):
+        mc = MembraneCurvature(
+            universe_dummy_full,
+            select='all',
+            surface_method='binning',
+            fft_filter=None,
+            n_x_bins=3,
+            n_y_bins=3,
+        )
+        assert mc.curvature_average == 'per_frame'
+
+    def test_invalid_curvature_average(self, universe_dummy_full):
+        with pytest.raises(ValueError, match=r'curvature_average must be one of'):
+            MembraneCurvature(
+                universe_dummy_full,
+                select='all',
+                surface_method='binning',
+                fft_filter=None,
+                curvature_average='invalid',
+            )
+
+    def test_curvature_average_surface_binning(self, universe_dummy_full):
+        mc = MembraneCurvature(
+            universe_dummy_full,
+            select='all',
+            surface_method='binning',
+            fft_filter=None,
+            curvature_average='surface',
+            n_x_bins=3,
+            n_y_bins=3,
+        ).run()
+        expected_mean = mean_curvature(mc.results.average_z_surface, mc.dx, mc.dy)
+        expected_gaussian = gaussian_curvature(mc.results.average_z_surface, mc.dx, mc.dy)
+        assert_almost_equal(mc.results.average_mean, expected_mean)
+        assert_almost_equal(mc.results.average_gaussian, expected_gaussian)
+
+    def test_curvature_average_per_frame_differs_from_surface(self, universe_dummy_full):
+        mc_pf = MembraneCurvature(
+            universe_dummy_full,
+            select='all',
+            surface_method='binning',
+            fft_filter=None,
+            curvature_average='per_frame',
+            n_x_bins=3,
+            n_y_bins=3,
+        ).run()
+        mc_sf = MembraneCurvature(
+            universe_dummy_full,
+            select='all',
+            surface_method='binning',
+            fft_filter=None,
+            curvature_average='surface',
+            n_x_bins=3,
+            n_y_bins=3,
+        ).run()
+        assert_almost_equal(mc_pf.results.average_z_surface, mc_sf.results.average_z_surface)
+        assert mc_pf.results.average_mean.shape == (3, 3)
+        assert mc_sf.results.average_mean.shape == (3, 3)
+
+    def test_curvature_average_surface_with_padding(self, universe_dummy_full):
+        mc = MembraneCurvature(
+            universe_dummy_full,
+            select='all',
+            surface_method='binning',
+            fft_filter=None,
+            curvature_average='surface',
+            padding=True,
+            edge_pad_bins=1,
+            n_x_bins=3,
+            n_y_bins=3,
+        ).run()
+        assert mc.results.average_mean.shape == (3, 3)
+        assert mc.results.average_gaussian.shape == (3, 3)
+        assert np.any(np.isfinite(mc.results.average_mean))
+
+    def test_curvature_average_surface_with_fft_filter(self, universe_dummy_full):
+        mc = MembraneCurvature(
+            universe_dummy_full,
+            select='all',
+            surface_method='binning',
+            fft_filter='auto',
+            curvature_average='surface',
+            n_x_bins=3,
+            n_y_bins=3,
+        ).run()
+        assert mc.results.average_mean.shape == (3, 3)
+        assert mc.results.average_gaussian.shape == (3, 3)
+        assert np.any(np.isfinite(mc.results.average_mean))
+
+    def test_curvature_average_surface_fourier(self, universe_fourier_defaults):
+        mc = MembraneCurvature(
+            universe_fourier_defaults,
+            curvature_average='surface',
+        ).run()
+        assert mc.results.average_mean.shape == (100, 100)
+        assert mc.results.average_gaussian.shape == (100, 100)
+        expected = mean_curvature(mc.results.average_z_surface, mc.dx, mc.dy)
+        assert_almost_equal(mc.results.average_mean, expected)
+
+    def test_curvature_average_explicit_per_frame_matches_default(self, universe_dummy_full):
+        mc_default = MembraneCurvature(
+            universe_dummy_full,
+            select='all',
+            surface_method='binning',
+            fft_filter=None,
+            n_x_bins=3,
+            n_y_bins=3,
+        ).run()
+        mc_explicit = MembraneCurvature(
+            universe_dummy_full,
+            select='all',
+            surface_method='binning',
+            fft_filter=None,
+            curvature_average='per_frame',
+            n_x_bins=3,
+            n_y_bins=3,
+        ).run()
+        assert_almost_equal(mc_default.results.average_mean, mc_explicit.results.average_mean)
+        assert_almost_equal(mc_default.results.average_gaussian, mc_explicit.results.average_gaussian)


### PR DESCRIPTION
Fixes #248

## Description

This PR introduces the `curvature_average` parameter to `MembraneCurvature`, allowing users to explicitly select between two averaging schemes:

- `curvature_average='per_frame'` (default): Computes the time average of per-frame curvature maps ($\langle H \rangle$ and $\langle K \rangle$).
- `curvature_average='surface'`: Evaluates curvature directly on the time-averaged height surface ($H(\langle S \rangle)$ and $K(\langle S \rangle)$).

### Background & Rationale

Because curvature is a non-linear function of the height field, $\langle H \rangle \neq H(\langle S \rangle)$ in general:

- $\langle H \rangle$ represents the average of the instantaneous curvature maps and therefore includes contributions from thermal fluctuations.
- $H(\langle S \rangle)$ evaluates curvature after thermal fluctuations have canceled out in height over the trajectory, yielding the curvature of the overall time-averaged membrane shape.

### API Usage (Before vs. After)

**Before (manual calculation required for H(⟨S⟩)):**

```python
from membrane_curvature.curvature import mean_curvature

mc = MembraneCurvature(u, select='name PO4').run()

# H(⟨S⟩) required manually calling low-level helper functions
H_of_S = mean_curvature(mc.results.average_z_surface, mc.dx, mc.dy)
```

**After (supported natively via API):**

```python
# H(⟨S⟩) — curvature of time-averaged surface
mc_shape = MembraneCurvature(u, select='name PO4', curvature_average='surface').run()
H_of_S = mc_shape.results.average_mean

# ⟨H⟩ — average of per-frame curvatures (default behavior)
mc_fluct = MembraneCurvature(u, select='name PO4', curvature_average='per_frame').run()
H_avg = mc_fluct.results.average_mean
```

## Changes made in this Pull Request

- Added `curvature_average` parameter (`'per_frame'` | `'surface'`) to `MembraneCurvature.__init__()` with validation via `CurvatureAverage` enum.
- Updated `_conclude()` in `base.py` to compute `average_mean` and `average_gaussian` either by averaging per-frame curvature maps (default) or by evaluating curvature on `average_z_surface`, depending on `curvature_average`.
- Added unit tests in `test_membrane_curvature.py` covering default behavior, parameter validation, binning, Fourier, padding, and FFT-filtering interactions.
- Updated documentation in `Algorithm.rst` and `Usage.rst` explaining the mathematical distinction and providing usage examples.
- Updated `CHANGELOG.rst` under unreleased changes.

## PR Checklist

- [x] Issue raised/referenced
- [x] Tests updated/added
- [x] Documentation updated/added
- [x] `CHANGELOG` file updated