### PR TITLE
Feature: add ``curvature_on`` kwarg to calculate curvature from average surface

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Membranecurvature CHANGELOG
 
 ---
 
+* Enabled ``curvature_on`` kwarg to calculate curvature as ``per-frame`` average or as
+  ``'average_surface'``.
 * Added ``surface_method='binning_nearest'`` as a new surface method (PR #246)
 * Feature: Added periodic edge padding for the binning surface method (PR #238)
 * Refactored binning surface method to use ``np.add.at`` for improved performance (PR #240)

--- a/membrane_curvature/base.py
+++ b/membrane_curvature/base.py
@@ -264,18 +264,18 @@ class MembraneCurvature(AnalysisBase):
         FOURIER = 'fourier'
 
     class CurvatureOn(StrEnum):
-        """Supported values for ``curvature_on``.
+        r"""Supported values for ``curvature_on``.
 
-        Where to evaluate curvature for ``results.average_mean`` and ``results.average_gaussian``.
+        Where to evaluate curvature for ``results.average_mean`` and ``results.average_gaussian``:
 
-        -  ``'per_frame'`` time-averages the per-frame curvature arrays
-            (:math:`\langle H \rangle`, :math:`\langle K \rangle`).
-
-        - ``'average_surface'`` evaluates curvature on ``results.average_z_surface``
-            (:math:`H(\langle S \rangle)`, :math:`K(\langle S \rangle)`).
-
-        - ``None`` (default) keeps prior behavior: ``'per_frame'`` when ``fft_filter`` is
-            ``None``, and ``'average_surface'`` when ``fft_filter`` is set.
+        ``'per_frame'``
+            Time averages the per-frame curvature arrays (:math:`\langle H \rangle`, :math:`\langle K \rangle`).
+        ``'average_surface'``
+            Evaluates curvature on ``results.average_z_surface`` :math:`H(\langle S \rangle)`,
+            :math:`K(\langle S \rangle)`.
+        ``None`` (default)
+            Keeps prior behavior: ``'per_frame'`` when ``fft_filter`` is ``None``, and
+            ``'average_surface'`` when ``fft_filter`` is set.
         """
 
         PER_FRAME = 'per_frame'

--- a/membrane_curvature/base.py
+++ b/membrane_curvature/base.py
@@ -111,9 +111,13 @@ class MembraneCurvature(AnalysisBase):
         ``surface_method='binning_nearest'``. Default is ``None``. Pass ``'auto'`` to enable
         automatic filtering with low-pass set to ``(0, 0.5 * q_Nyq)``. For custom bounds in
         rad/Å, pass ``{'q': (q_low, q_high)}``. For **average** maps: time-average of
-        ``z_surface``, filter once, then curvature on that filtered height.
+        ``z_surface``, filter once, then curvature on that filtered height when
+        ``curvature_on`` resolves to ``'average_surface'``.
         Per-frame arrays are not FFT-filtered. Ignored for ``surface_method='fourier'``.
         Compatible with ``padding``. Not allowed with ``grid_origin='lipid_bbox'``.
+    curvature_on : str, optional, default: None
+        Where to evaluate curvature for ``results.average_mean`` and ``results.average_gaussian``.
+        See :class:`CurvatureOn` for more details.
     padding : bool, optional
         Apply periodic edge padding for binning surface methods. Default ``False``.
         For ``surface_method='binning'``, pads the simulation box using periodic images
@@ -144,14 +148,16 @@ class MembraneCurvature(AnalysisBase):
         temporal mean of ``z_surface``, not the mean of per-frame filtered surfaces.
         Each array has shape (`n_x_bins`, `n_y_bins`)
     results.average_mean : ndarray
-        Average of the array elements in `mean_curvature`. With ``binning`` or
-        ``binning_nearest`` and ``fft_filter`` enabled, curvature of the filtered
-        time-averaged height (not the time average of per-frame ``results.mean``).
+        Mean curvature map for analysis and plotting.
+        With ``curvature_on='per_frame'``, the time average of ``results.mean``.
+        With ``curvature_on='average_surface'``, mean curvature of
+        ``results.average_z_surface``.
         Each array has shape (`n_x_bins`, `n_y_bins`)
     results.average_gaussian : ndarray
-        Average of the array elements in `gaussian_curvature`. With ``binning`` or
-        ``binning_nearest`` and ``fft_filter`` enabled, curvature of the filtered
-        time-averaged height (not the time average of per-frame ``results.gaussian``).
+        Gaussian curvature map for analysis and plotting.
+        With ``curvature_on='per_frame'``, the time average of ``results.gaussian``.
+        With ``curvature_on='average_surface'``, Gaussian curvature of
+        ``results.average_z_surface``.
         Each array has shape (`n_x_bins`, `n_y_bins`)
 
     Raises
@@ -167,8 +173,9 @@ class MembraneCurvature(AnalysisBase):
         ``surface_method='fourier'``, if a manual ``fft_filter`` dict is passed
         with ``surface_method='fourier'``, if ``padding=True`` with
         ``surface_method='fourier'``, if ``padding=True`` on a
-        non-orthorhombic box, or if ``edge_pad_bins`` is not an integer
-        ``>= 1`` when ``padding=True``.
+        non-orthorhombic box, if ``edge_pad_bins`` is not an integer
+        ``>= 1`` when ``padding=True``, or if ``curvature_on`` is not
+        ``None``, ``'per_frame'``, or ``'average_surface'``.
 
     See also
     --------
@@ -213,9 +220,15 @@ class MembraneCurvature(AnalysisBase):
 
     The attributes :attr:`~MembraneCurvature.results.average_mean` and
     :attr:`~MembraneCurvature.results.average_gaussian` contain mean and
-    Gaussian curvature maps for analysis and plotting. With ``fft_filter`` on
-    binning surfaces they are curvatures of the filtered average height, not the
-    time average of per-frame curvatures.
+    Gaussian curvature maps for analysis and plotting. With
+    ``curvature_on='per_frame'`` the arrays are time averages of the per-frame
+    curvature arrays. With ``curvature_on='average_surface'`` the arrays are curvatures
+    of ``average_z_surface`` (including after ``fft_filter`` when that is set).
+    Leaving ``curvature_on=None`` preserves the previous defaults:
+    ``'per_frame'`` when ``fft_filter`` is ``None``, and ``'average_surface'`` when
+    ``fft_filter`` is set.
+
+
 
     Example
     -----------
@@ -244,11 +257,29 @@ class MembraneCurvature(AnalysisBase):
     """
 
     class SurfaceMethod(StrEnum):
-        """Allowed values for ``surface_method``."""
+        """Supported values for ``surface_method``."""
 
         BINNING = 'binning'
         BINNING_NEAREST = 'binning_nearest'
         FOURIER = 'fourier'
+
+    class CurvatureOn(StrEnum):
+        """Supported values for ``curvature_on``.
+
+        Where to evaluate curvature for ``results.average_mean`` and ``results.average_gaussian``.
+
+        -  ``'per_frame'`` time-averages the per-frame curvature arrays
+            (:math:`\langle H \rangle`, :math:`\langle K \rangle`).
+
+        - ``'average_surface'`` evaluates curvature on ``results.average_z_surface``
+            (:math:`H(\langle S \rangle)`, :math:`K(\langle S \rangle)`).
+
+        - ``None`` (default) keeps prior behavior: ``'per_frame'`` when ``fft_filter`` is
+            ``None``, and ``'average_surface'`` when ``fft_filter`` is set.
+        """
+
+        PER_FRAME = 'per_frame'
+        AVERAGE_SURFACE = 'average_surface'
 
     def __init__(
         self,
@@ -264,6 +295,7 @@ class MembraneCurvature(AnalysisBase):
         fourier_n=2,
         fourier_rcond=None,
         fft_filter=None,
+        curvature_on=None,
         padding=False,
         edge_pad_bins=2,
         grid_origin='box',
@@ -370,6 +402,8 @@ class MembraneCurvature(AnalysisBase):
                     f'q_low={self._fft_q_bounds[0]:.6g}, q_high={self._fft_q_bounds[1]:.6g} (rad/A)',
                 )
 
+        self.curvature_on = self._resolve_curvature_on(curvature_on)
+
         # Only checks the first frame. NPT simulations not properly covered here.
         # Warning message if range doesn't cover entire dimensions of simulation box
         for dim_string, dim_range, num in [('x', self.x_range, 0), ('y', self.y_range, 1)]:
@@ -394,6 +428,18 @@ class MembraneCurvature(AnalysisBase):
             )
             warnings.warn(msg)
             logger.warning(msg)
+
+    def _resolve_curvature_on(self, curvature_on):
+        """Resolve curvature calculation mode depending on the value of `curvature_on`."""
+        if curvature_on is None:
+            if self._fft_q_bounds is not None:
+                return self.CurvatureOn.AVERAGE_SURFACE
+            return self.CurvatureOn.PER_FRAME
+        try:
+            return self.CurvatureOn(curvature_on)
+        except ValueError as err:
+            allowed = ', '.join(repr(method.value) for method in self.CurvatureOn)
+            raise ValueError(f'curvature_on must be None or one of ({allowed}), got {curvature_on!r}') from err
 
     def _wrap_xy(self):
         """Wrap x,y into the unit cell and leave z unchanged."""
@@ -485,20 +531,23 @@ class MembraneCurvature(AnalysisBase):
 
     def _conclude(self):
         z_average = np.nanmean(self.results.z_surface, axis=0)
-        # apply filter when enabled
         if self._fft_q_bounds is not None:
             self.results.average_z_surface = apply_fft_filter(z_average, self.dx, self.dy, self._fft_q_bounds)
-            z_filtered = self.results.average_z_surface
-            if self.padding:
-                _, avg_mean, avg_gauss = curvature_from_primary_with_edge_pad(
-                    z_filtered, self.dx, self.dy, self.edge_pad_bins
-                )
-                self.results.average_mean = avg_mean
-                self.results.average_gaussian = avg_gauss
-            else:
-                self.results.average_mean = mean_curvature(z_filtered, self.dx, self.dy)
-                self.results.average_gaussian = gaussian_curvature(z_filtered, self.dx, self.dy)
         else:
             self.results.average_z_surface = z_average
+
+        if self.curvature_on == self.CurvatureOn.PER_FRAME:
             self.results.average_mean = np.nanmean(self.results.mean, axis=0)
             self.results.average_gaussian = np.nanmean(self.results.gaussian, axis=0)
+            return
+
+        z_for_curvature = self.results.average_z_surface
+        if self.padding:
+            _, avg_mean, avg_gauss = curvature_from_primary_with_edge_pad(
+                z_for_curvature, self.dx, self.dy, self.edge_pad_bins
+            )
+            self.results.average_mean = avg_mean
+            self.results.average_gaussian = avg_gauss
+        else:
+            self.results.average_mean = mean_curvature(z_for_curvature, self.dx, self.dy)
+            self.results.average_gaussian = gaussian_curvature(z_for_curvature, self.dx, self.dy)

--- a/membrane_curvature/tests/test_fft_filtering.py
+++ b/membrane_curvature/tests/test_fft_filtering.py
@@ -4,7 +4,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from membrane_curvature.binning_surface import get_z_surface
-from membrane_curvature.curvature import mean_curvature
+from membrane_curvature.curvature import mean_curvature, gaussian_curvature
 from membrane_curvature.fft_filtering import (
     _height_for_fft,
     _squared_radius_grid,
@@ -286,3 +286,127 @@ def test_membrane_curvature_binning_fft_filter_none(universe_dummy_wrap):
 
     assert mc.fft_filter is None
     assert_allclose(mc.results.average_z_surface, expected, rtol=0)
+
+
+@pytest.mark.parametrize(
+    'fft_filter, expected',
+    [
+        (None, MembraneCurvature.CurvatureOn.PER_FRAME),
+        ('auto', MembraneCurvature.CurvatureOn.AVERAGE_SURFACE),
+    ],
+)
+def test_curvature_on_default_follows_fft_filter(universe_dummy_wrap, fft_filter, expected):
+    mc = MembraneCurvature(
+        universe_dummy_wrap,
+        n_x_bins=3,
+        n_y_bins=3,
+        surface_method='binning',
+        fft_filter=fft_filter,
+    )
+    assert mc.curvature_on == expected
+
+
+@pytest.mark.parametrize('curvature_on', ['per_frame', 'average_surface'])
+def test_curvature_on_explicit_overrides_default(universe_dummy_wrap, curvature_on):
+    mc_no_filter = MembraneCurvature(
+        universe_dummy_wrap,
+        n_x_bins=3,
+        n_y_bins=3,
+        surface_method='binning',
+        fft_filter=None,
+        curvature_on=curvature_on,
+    )
+    mc_with_filter = MembraneCurvature(
+        universe_dummy_wrap,
+        n_x_bins=3,
+        n_y_bins=3,
+        surface_method='binning',
+        fft_filter='auto',
+        curvature_on=curvature_on,
+    )
+    assert mc_no_filter.curvature_on == MembraneCurvature.CurvatureOn(curvature_on)
+    assert mc_with_filter.curvature_on == MembraneCurvature.CurvatureOn(curvature_on)
+
+
+def test_curvature_on_rejects_invalid_value(universe_dummy_wrap):
+    with pytest.raises(ValueError, match=r"curvature_on must be None or one of .*got 'frames'"):
+        MembraneCurvature(
+            universe_dummy_wrap,
+            n_x_bins=3,
+            n_y_bins=3,
+            surface_method='binning',
+            curvature_on='frames',
+        )
+
+
+def test_curvature_on_per_frame_is_time_mean_of_per_frame_maps(universe_dummy_wrap):
+    mc = MembraneCurvature(
+        universe_dummy_wrap,
+        n_x_bins=3,
+        n_y_bins=3,
+        surface_method='binning',
+        fft_filter=None,
+        curvature_on='per_frame',
+    ).run()
+    assert_allclose(mc.results.average_mean, np.nanmean(mc.results.mean, axis=0), equal_nan=True)
+    assert_allclose(mc.results.average_gaussian, np.nanmean(mc.results.gaussian, axis=0), equal_nan=True)
+
+
+def test_curvature_on_average_surface_is_curvature_of_average_z(universe_dummy_wrap):
+    mc = MembraneCurvature(
+        universe_dummy_wrap,
+        n_x_bins=3,
+        n_y_bins=3,
+        surface_method='binning',
+        fft_filter=None,
+        curvature_on='average_surface',
+    ).run()
+    assert_allclose(
+        mc.results.average_mean,
+        mean_curvature(mc.results.average_z_surface, mc.dx, mc.dy),
+        equal_nan=True,
+    )
+    assert_allclose(
+        mc.results.average_gaussian,
+        gaussian_curvature(mc.results.average_z_surface, mc.dx, mc.dy),
+        equal_nan=True,
+    )
+
+
+def test_curvature_on_per_frame_with_fft_filter_keeps_unfiltered_H(universe_dummy_wrap):
+    """With fft_filter, 'per_frame' averages unfiltered H; 'average_surface' uses filtered ⟨S⟩."""
+    n_bins = 3
+    dx = dy = universe_dummy_wrap.dimensions[0] / n_bins
+    q_bounds = resolve_fft_filter('auto', dx, dy)
+    common = dict(
+        universe=universe_dummy_wrap,
+        n_x_bins=n_bins,
+        n_y_bins=n_bins,
+        surface_method='binning',
+        fft_filter='auto',
+    )
+    mc_average = MembraneCurvature(**common, curvature_on='average_surface').run()
+    mc_per_frame = MembraneCurvature(**common, curvature_on='per_frame').run()
+
+    assert_allclose(mc_average.results.average_z_surface, mc_per_frame.results.average_z_surface, equal_nan=True)
+    assert_allclose(
+        mc_average.results.average_mean,
+        mean_curvature(mc_average.results.average_z_surface, dx, dy),
+        equal_nan=True,
+    )
+    assert_allclose(
+        mc_per_frame.results.average_mean,
+        np.nanmean(mc_per_frame.results.mean, axis=0),
+        equal_nan=True,
+    )
+    assert not np.allclose(mc_average.results.average_mean, mc_per_frame.results.average_mean, equal_nan=True)
+    assert not np.allclose(
+        mc_per_frame.results.average_z_surface,
+        mc_per_frame.results.z_surface[0],
+        equal_nan=True,
+    )
+    assert_allclose(
+        apply_fft_filter(mc_per_frame.results.z_surface[0], dx, dy, q_bounds),
+        mc_per_frame.results.average_z_surface,
+        equal_nan=True,
+    )


### PR DESCRIPTION
<!--
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #251  

## Description
<!--
Provide a brief description of the PR's purpose here.
-->
Enabled ``curvature_on`` kwarg to calculate curvature from the per-frame average of H and K, or from the averaged surface. Note that the current behaviour of MC matches ``per-frame`` which is also reproduced with `None` for backward compatibility.

Note that documentation is not included in this PR.

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use a bullet list. -->
-  Added kwarg ``curvature_on`` with values ``per-frame``, ``'average_surface'`` or `None`.
- Created Class Enum CurvatureOn for supported values.

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [N/A] Documentation updated/added?
 - [x] `CHANGELOG` file updated?
