### PR TITLE
Docs: Update doc pages to include `curvature_on` kwarg

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,6 @@ Chronological list of authors
 
 2024
   - Christopher Lee
+
+2026 
+  - Sarvesh Shahane

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,9 @@ Membranecurvature CHANGELOG
 
 ---
 
+* Expose and document ``nyquist_q`` to set manual FFT filter bounds (PR #241)
 * Enabled ``curvature_on`` kwarg to calculate curvature as ``per-frame`` average or as
-  ``'average_surface'``.
+  ``'average_surface'`` (PR #250 #253).
 * Added ``surface_method='binning_nearest'`` as a new surface method (PR #246)
 * Feature: Added periodic edge padding for the binning surface method (PR #238)
 * Refactored binning surface method to use ``np.add.at`` for improved performance (PR #240)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,7 +4,8 @@ MembraneCurvature's API Documentation
 
 The MembraneCurvature API is built around the :class:`~membrane_curvature.base.MembraneCurvature` class, which loads trajectory and coordinate
 files, and provides routines to derive a surface from atom positions. The resulting surface is then used to compute mean and Gaussian curvature,
-either for individual frames or averaged across multiple frames of an MD trajectory.
+either for individual frames or averaged across multiple frames of an MD trajectory. Average maps can be computed as the time average of per-frame curvatures
+or evaluated directly on the time-averaged surface via the ``curvature_on`` argument.
 
 To use :class:`~membrane_curvature.base.MembraneCurvature`, users must provide at least two inputs: an MDAnalysis
 :class:`~MDAnalysis.core.universe.Universe`, and an :class:`~MDAnalysis.core.groups.AtomGroup` used as the reference to derive the surface and
@@ -92,6 +93,8 @@ The functions in :mod:`~membrane_curvature.curvature` include both analytical an
      from the discrete height field using finite differences.
 
 In both cases, the derivatives are then used to calculate mean and Gaussian curvature using the Monge-gauge formulas.
+
+Average curvature maps (:attr:`~membrane_curvature.base.MembraneCurvature.results.average_mean` and :attr:`~membrane_curvature.base.MembraneCurvature.results.average_gaussian`) can be calculated either as the time average of per-frame curvature maps (``curvature_on='per_frame'``: :math:`\langle H \rangle`, :math:`\langle K \rangle`) or evaluated directly on the time-averaged surface (``curvature_on='average_surface'``: :math:`H(\langle S \rangle)`, :math:`K(\langle S \rangle)`).
 
 .. toctree::
    :maxdepth: 1

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,8 +4,7 @@ MembraneCurvature's API Documentation
 
 The MembraneCurvature API is built around the :class:`~membrane_curvature.base.MembraneCurvature` class, which loads trajectory and coordinate
 files, and provides routines to derive a surface from atom positions. The resulting surface is then used to compute mean and Gaussian curvature,
-either for individual frames or averaged across multiple frames of an MD trajectory. Average maps can be computed as the time average of per-frame curvatures
-or evaluated directly on the time-averaged surface via the ``curvature_on`` argument.
+either for individual frames or averaged across multiple frames of an MD trajectory.
 
 To use :class:`~membrane_curvature.base.MembraneCurvature`, users must provide at least two inputs: an MDAnalysis
 :class:`~MDAnalysis.core.universe.Universe`, and an :class:`~MDAnalysis.core.groups.AtomGroup` used as the reference to derive the surface and
@@ -94,7 +93,7 @@ The functions in :mod:`~membrane_curvature.curvature` include both analytical an
 
 In both cases, the derivatives are then used to calculate mean and Gaussian curvature using the Monge-gauge formulas.
 
-Average curvature maps (:attr:`~membrane_curvature.base.MembraneCurvature.results.average_mean` and :attr:`~membrane_curvature.base.MembraneCurvature.results.average_gaussian`) can be calculated either as the time average of per-frame curvature maps (``curvature_on='per_frame'``: :math:`\langle H \rangle`, :math:`\langle K \rangle`) or evaluated directly on the time-averaged surface (``curvature_on='average_surface'``: :math:`H(\langle S \rangle)`, :math:`K(\langle S \rangle)`).
+:class:`~membrane_curvature.base.MembraneCurvature` supports two different approaches to obtain average curvature maps: as the time average of per-frame curvatures, or by calculating curvature directly on the time-averaged surface.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/pages/Algorithm.rst
+++ b/docs/source/pages/Algorithm.rst
@@ -665,7 +665,7 @@ How those averages are built depends on ``curvature_on`` and ``fft_filter``:
 
 When ``curvature_on=None`` (the default), curvature is calculated on the time-averaged surface if an FFT filter is specified, or as a per-frame average if no filter is used.
 
-4.1 Distinguishing curvature of average surface vs. average of per-frame curvatures
+4.1 Calculating curvature from average surface vs. average of per-frame curvatures
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Per-frame time averaging calculates curvature maps for each frame :math:`H_i` and :math:`K_i` before averaging across frames:
@@ -688,7 +688,7 @@ The two approaches capture distinct physical quantities:
 - **Per-frame average**: Calculates curvature for each frame individually and then averages over time. This preserves the mean contribution of instantaneous thermal fluctuations.
 - **Average surface curvature**: Time-averages the surface height field :math:`z(x,y)` over the trajectory first (allowing uncorrelated thermal fluctuations to cancel out), and then calculates curvature on the resulting smooth time-averaged surface.
 
-4.2 Controlling average curvature calculation mode (``curvature_on``)
+4.2 Curvature calculation mode (``curvature_on``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The calculation of :attr:`~membrane_curvature.base.MembraneCurvature.results.average_mean` and :attr:`~membrane_curvature.base.MembraneCurvature.results.average_gaussian` is controlled by the ``curvature_on`` parameter:

--- a/docs/source/pages/Algorithm.rst
+++ b/docs/source/pages/Algorithm.rst
@@ -660,42 +660,43 @@ Each array has shape ``(n_x_bins, n_y_bins)``.
 
 How those averages are built depends on ``curvature_on`` and ``fft_filter``:
 
-- With ``curvature_on='per_frame'``, average maps are time averages of per-frame curvature maps:
-  :math:`\langle H \rangle` and :math:`\langle K \rangle`.
-- With ``curvature_on='average_surface'``, average maps are curvatures evaluated directly on the time-averaged surface height field:
-  :math:`H(\langle S \rangle)` and :math:`K(\langle S \rangle)`.
-- Leaving ``curvature_on=None`` (default) preserves prior behavior: ``'per_frame'`` when ``fft_filter=None``, and ``'average_surface'`` when ``fft_filter`` is set.
+- With ``curvature_on='per_frame'``, the average curvature maps are the time average of the per-frame curvatures.
+- With ``curvature_on='average_surface'``, the average curvature maps are calculated directly on the time-averaged surface height field.
+
+When ``curvature_on=None`` (the default), curvature is calculated on the time-averaged surface if an FFT filter is specified, or as a per-frame average if no filter is used.
 
 4.1 Distinguishing curvature of average surface vs. average of per-frame curvatures
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Per-frame time averaging calculates curvature maps for each frame :math:`H_i` and :math:`K_i` before averaging across frames:
+
+.. math::
+
+   \langle H \rangle = \frac{1}{N_{\text{frames}}} \sum_{i=1}^{N_{\text{frames}}} H_i, \qquad \langle K \rangle = \frac{1}{N_{\text{frames}}} \sum_{i=1}^{N_{\text{frames}}} K_i
+
 Because curvature is a non-linear function of the surface height field :math:`z(x, y)`,
-evaluating curvature on the time-averaged surface is mathematically distinct from time-averaging per-frame curvature maps:
+deriving curvature from a time-averaged surface is different from calculating curvature by time averaging curvature maps on every frame:
 
 .. math::
 
    \langle H \rangle \neq H(\langle S \rangle), \qquad \langle K \rangle \neq K(\langle S \rangle)
 
-where:
-
-- :math:`\langle H \rangle` and :math:`\langle K \rangle` are the time-averaged per-frame curvatures (the mean over all frames of per-frame curvature maps :math:`H_i` and :math:`K_i`).
-- :math:`H(\langle S \rangle)` and :math:`K(\langle S \rangle)` are the mean and Gaussian curvatures evaluated directly on the time-averaged surface height field :math:`\langle S \rangle = \text{average\_z\_surface}` (including after optional FFT filtering).
+where :math:`\langle H \rangle` and :math:`\langle K \rangle` are the time-averaged per-frame curvatures, while :math:`H(\langle S \rangle)` and :math:`K(\langle S \rangle)` represent the mean and Gaussian curvatures calculated directly on the time-averaged surface height field.
 
 The two approaches capture distinct physical quantities:
 
-- **Per-frame average** (:math:`\langle H \rangle`, :math:`\langle K \rangle`): Evaluates curvature for each frame individually and then averages over time. This preserves the mean contribution of instantaneous thermal fluctuations.
-- **Average surface curvature** (:math:`H(\langle S \rangle)`, :math:`K(\langle S \rangle)`): Time-averages the surface height field :math:`z(x,y)` over the trajectory first (allowing uncorrelated thermal fluctuations to cancel out), and then evaluates curvature on the resulting smooth time-averaged surface :math:`\langle S \rangle`.
+- **Per-frame average**: Calculates curvature for each frame individually and then averages over time. This preserves the mean contribution of instantaneous thermal fluctuations.
+- **Average surface curvature**: Time-averages the surface height field :math:`z(x,y)` over the trajectory first (allowing uncorrelated thermal fluctuations to cancel out), and then calculates curvature on the resulting smooth time-averaged surface.
 
-4.2 Controlling average curvature evaluation mode (``curvature_on``)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+4.2 Controlling average curvature calculation mode (``curvature_on``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The evaluation mode for :attr:`~membrane_curvature.base.MembraneCurvature.results.average_mean` and :attr:`~membrane_curvature.base.MembraneCurvature.results.average_gaussian` is controlled by the ``curvature_on`` parameter:
+The calculation of :attr:`~membrane_curvature.base.MembraneCurvature.results.average_mean` and :attr:`~membrane_curvature.base.MembraneCurvature.results.average_gaussian` is controlled by the ``curvature_on`` parameter:
 
-- ``curvature_on='per_frame'``: Computes :math:`\langle H \rangle` and :math:`\langle K \rangle` as the temporal mean of per-frame curvature maps (``results.mean`` and ``results.gaussian``).
-- ``curvature_on='average_surface'``: Evaluates :math:`H(\langle S \rangle)` and :math:`K(\langle S \rangle)` on ``results.average_z_surface``.
-- ``curvature_on=None`` (default): Preserves prior default behaviors:
-  - When ``fft_filter`` is ``None``, defaults to ``'per_frame'``.
-  - When ``fft_filter`` is enabled (``'auto'`` or a custom passband dict), defaults to ``'average_surface'`` (evaluates curvature on the FFT-filtered time-averaged surface).
+- ``curvature_on='per_frame'``: Calculates average curvatures as the temporal mean of per-frame curvature maps (``results.mean`` and ``results.gaussian``).
+- ``curvature_on='average_surface'``: Calculates average curvatures on ``results.average_z_surface``.
+
+Note that with the brick-wall FFT filter, curvature is calculated on the time-averaged surface. Without it, the default is a per-frame average.
 
 |avg_frames|
 

--- a/docs/source/pages/Algorithm.rst
+++ b/docs/source/pages/Algorithm.rst
@@ -365,10 +365,10 @@ trajectory averages use :func:`numpy.nanmean` and therefore ignore empty bins.
     calculating curvature on a **raw trajectory**. Heights in ``z`` are preserved.
   - Set ``wrap=False`` to leave atoms outside the primary cell in ``x`` and ``y``
     out of the bins when you are calculating curvature on:
-      - a trajectory (membrane only or membrane-protein with position restraints) that
-        already **pre-processed periodic boundary conditions**. 
-      - a membrane-protein system that already **pre-processes rotational and translational
-        fit for the protein**.
+    - a trajectory (membrane only or membrane-protein with position restraints) that
+      already **pre-processed periodic boundary conditions**. 
+    - a membrane-protein system that already **pre-processes rotational and translational
+      fit for the protein**.
   - With ``padding=True``, periodic images in ``x`` and ``y`` are tiled into the
     buffer even if ``wrap=False``, so the usual ``wrap == False`` warning is not
     emitted.
@@ -658,15 +658,44 @@ After the trajectory is processed, MembraneCurvature stores the averaged maps in
 :attr:`MembraneCurvature.results.average_gaussian` arrays, respectively.
 Each array has shape ``(n_x_bins, n_y_bins)``.
 
-How those averages are built depends on ``fft_filter``:
+How those averages are built depends on ``curvature_on`` and ``fft_filter``:
 
-- With the default ``fft_filter=None``, the average maps are time averages of the
-  per-frame arrays ``z_surface``, ``mean``, and ``gaussian``.
-- With ``fft_filter`` enabled (``'auto'`` or a manual ``{'q': ...}`` dict),
-  MembraneCurvature first time-averages ``z_surface``, applies one brick-wall
-  filter to that average, and then computes ``average_mean`` and
-  ``average_gaussian`` from the filtered average height.
-  The per-frame arrays stay unfiltered.
+- With ``curvature_on='per_frame'``, average maps are time averages of per-frame curvature maps:
+  :math:`\langle H \rangle` and :math:`\langle K \rangle`.
+- With ``curvature_on='average_surface'``, average maps are curvatures evaluated directly on the time-averaged surface height field:
+  :math:`H(\langle S \rangle)` and :math:`K(\langle S \rangle)`.
+- Leaving ``curvature_on=None`` (default) preserves prior behavior: ``'per_frame'`` when ``fft_filter=None``, and ``'average_surface'`` when ``fft_filter`` is set.
+
+4.1 Distinguishing curvature of average surface vs. average of per-frame curvatures
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Because curvature is a non-linear function of the surface height field :math:`z(x, y)`,
+evaluating curvature on the time-averaged surface is mathematically distinct from time-averaging per-frame curvature maps:
+
+.. math::
+
+   \langle H \rangle \neq H(\langle S \rangle), \qquad \langle K \rangle \neq K(\langle S \rangle)
+
+where:
+
+- :math:`\langle H \rangle` and :math:`\langle K \rangle` are the time-averaged per-frame curvatures (the mean over all frames of per-frame curvature maps :math:`H_i` and :math:`K_i`).
+- :math:`H(\langle S \rangle)` and :math:`K(\langle S \rangle)` are the mean and Gaussian curvatures evaluated directly on the time-averaged surface height field :math:`\langle S \rangle = \text{average\_z\_surface}` (including after optional FFT filtering).
+
+The two approaches capture distinct physical quantities:
+
+- **Per-frame average** (:math:`\langle H \rangle`, :math:`\langle K \rangle`): Evaluates curvature for each frame individually and then averages over time. This preserves the mean contribution of instantaneous thermal fluctuations.
+- **Average surface curvature** (:math:`H(\langle S \rangle)`, :math:`K(\langle S \rangle)`): Time-averages the surface height field :math:`z(x,y)` over the trajectory first (allowing uncorrelated thermal fluctuations to cancel out), and then evaluates curvature on the resulting smooth time-averaged surface :math:`\langle S \rangle`.
+
+4.2 Controlling average curvature evaluation mode (``curvature_on``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The evaluation mode for :attr:`~membrane_curvature.base.MembraneCurvature.results.average_mean` and :attr:`~membrane_curvature.base.MembraneCurvature.results.average_gaussian` is controlled by the ``curvature_on`` parameter:
+
+- ``curvature_on='per_frame'``: Computes :math:`\langle H \rangle` and :math:`\langle K \rangle` as the temporal mean of per-frame curvature maps (``results.mean`` and ``results.gaussian``).
+- ``curvature_on='average_surface'``: Evaluates :math:`H(\langle S \rangle)` and :math:`K(\langle S \rangle)` on ``results.average_z_surface``.
+- ``curvature_on=None`` (default): Preserves prior default behaviors:
+  - When ``fft_filter`` is ``None``, defaults to ``'per_frame'``.
+  - When ``fft_filter`` is enabled (``'auto'`` or a custom passband dict), defaults to ``'average_surface'`` (evaluates curvature on the FFT-filtered time-averaged surface).
 
 |avg_frames|
 

--- a/docs/source/pages/Usage.rst
+++ b/docs/source/pages/Usage.rst
@@ -358,7 +358,7 @@ To calculate curvature directly on the time-averaged surface, use ``curvature_on
     H_avg = mc_avg_per_frame.results.average_mean       
     K_avg = mc_avg_per_frame.results.average_gaussian   
 
-   mc_shape = MembraneCurvature(universe,
+    mc_avg_surface = MembraneCurvature(universe,
                                        select='resid 1-225 and name PO4',
                                        surface_method='binning',
                                        n_x_bins=8,
@@ -366,8 +366,8 @@ To calculate curvature directly on the time-averaged surface, use ``curvature_on
                                        curvature_on='average_surface',
                                        ).run()
 
-    H_of_S = mc_shape.results.average_mean
-    K_of_S = mc_shape.results.average_gaussian
+    H_of_S = mc_avg_surface.results.average_mean
+    K_of_S = mc_avg_surface.results.average_gaussian
 
 .. _membrane-protein:
 

--- a/docs/source/pages/Usage.rst
+++ b/docs/source/pages/Usage.rst
@@ -348,15 +348,15 @@ To calculate curvature directly on the time-averaged surface, use ``curvature_on
 
     universe = mda.Universe(Martini_membrane_gro)
 
-    mc_fluct = MembraneCurvature(universe,
+    mc_avg_per_frame = MembraneCurvature(universe,
                                          select='resid 1-225 and name PO4',
                                          surface_method='binning',
                                          n_x_bins=8,
                                          n_y_bins=8,
                                          ).run()
 
-    H_avg = mc_fluct.results.average_mean       
-    K_avg = mc_fluct.results.average_gaussian   
+    H_avg = mc_avg_per_frame.results.average_mean       
+    K_avg = mc_avg_per_frame.results.average_gaussian   
 
    mc_shape = MembraneCurvature(universe,
                                        select='resid 1-225 and name PO4',

--- a/docs/source/pages/Usage.rst
+++ b/docs/source/pages/Usage.rst
@@ -333,26 +333,12 @@ passing a tuple of ``(q_low, q_high)`` in rad/Å to ``fft_filter={'q': (q_low, q
 
 .. _curvature-on:
 
-2.1.2.3 Evaluating curvature on average surface vs. per-frame (``curvature_on``)
+2.1.2.3 Calculating curvature on average surface vs. per-frame (``curvature_on``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, :class:`~membrane_curvature.base.MembraneCurvature` computes average mean and Gaussian curvature maps as the time average of per-frame curvature maps:
+By default, :class:`~membrane_curvature.base.MembraneCurvature` computes average mean and Gaussian curvature maps as the time average of per-frame curvature maps.
 
-.. math::
-
-   \langle H \rangle = \frac{1}{N_{\text{frames}}} \sum_{i=1}^{N_{\text{frames}}} H_i, \qquad \langle K \rangle = \frac{1}{N_{\text{frames}}} \sum_{i=1}^{N_{\text{frames}}} K_i
-
-Because curvature is a non-linear function of the surface height field :math:`z(x, y)`, evaluating curvature on the time-averaged surface :math:`H(\langle S \rangle)` produces a mathematically distinct result:
-
-.. math::
-
-   \langle H \rangle \neq H(\langle S \rangle), \qquad \langle K \rangle \neq K(\langle S \rangle)
-
-To explicitly choose where curvature is evaluated for :attr:`~membrane_curvature.base.MembraneCurvature.results.average_mean` and :attr:`~membrane_curvature.base.MembraneCurvature.results.average_gaussian`, pass the ``curvature_on`` parameter:
-
-- ``curvature_on='per_frame'``: Evaluates curvature per frame and time-averages the resulting curvature maps (:math:`\langle H \rangle`, :math:`\langle K \rangle`). This retains the mean contribution of instantaneous thermal fluctuations.
-- ``curvature_on='average_surface'``: Time-averages the surface height field first (:attr:`~membrane_curvature.base.MembraneCurvature.results.average_z_surface`), and evaluates curvature on that average surface (:math:`H(\langle S \rangle)`, :math:`K(\langle S \rangle)`). Thermal fluctuations cancel out over the trajectory, isolating the curvature of the persistent equilibrium membrane shape.
-- ``curvature_on=None`` (default): Resolves to ``'per_frame'`` when ``fft_filter=None``, and ``'average_surface'`` when ``fft_filter`` is enabled.
+To calculate curvature directly on the time-averaged surface, use ``curvature_on='average_surface'``. To calculate curvature for each frame individually and average the resulting maps over time, use ``curvature_on='per_frame'``.
 
 .. code-block:: python
 
@@ -362,29 +348,26 @@ To explicitly choose where curvature is evaluated for :attr:`~membrane_curvature
 
     universe = mda.Universe(Martini_membrane_gro)
 
-    # 1. Time average of per-frame curvatures <H> and <K> (curvature_on='per_frame')
     mc_fluct = MembraneCurvature(universe,
-                                 select='resid 1-225 and name PO4',
-                                 surface_method='binning',
-                                 n_x_bins=8,
-                                 n_y_bins=8,
-                                 curvature_on='per_frame',
-                                 ).run()
+                                         select='resid 1-225 and name PO4',
+                                         surface_method='binning',
+                                         n_x_bins=8,
+                                         n_y_bins=8,
+                                         ).run()
 
-    H_avg = mc_fluct.results.average_mean       # <H>
-    K_avg = mc_fluct.results.average_gaussian   # <K>
+    H_avg = mc_fluct.results.average_mean       
+    K_avg = mc_fluct.results.average_gaussian   
 
-    # 2. Curvature of the time-averaged surface H(<S>) and K(<S>) (curvature_on='average_surface')
-    mc_shape = MembraneCurvature(universe,
-                                 select='resid 1-225 and name PO4',
-                                 surface_method='binning',
-                                 n_x_bins=8,
-                                 n_y_bins=8,
-                                 curvature_on='average_surface',
-                                 ).run()
+   mc_shape = MembraneCurvature(universe,
+                                       select='resid 1-225 and name PO4',
+                                       surface_method='binning',
+                                       n_x_bins=8,
+                                       n_y_bins=8,
+                                       curvature_on='average_surface',
+                                       ).run()
 
-    H_of_S = mc_shape.results.average_mean      # H(<S>)
-    K_of_S = mc_shape.results.average_gaussian  # K(<S>)
+    H_of_S = mc_shape.results.average_mean
+    K_of_S = mc_shape.results.average_gaussian
 
 .. _membrane-protein:
 

--- a/docs/source/pages/Usage.rst
+++ b/docs/source/pages/Usage.rst
@@ -330,6 +330,62 @@ passing a tuple of ``(q_low, q_high)`` in rad/Å to ``fft_filter={'q': (q_low, q
   When using the brick-wall filter, the recommended way is to use the automatic mode
   ``fft_filter='auto'`` with the default low-pass ``(0, 0.5 * q_Nyq)`` from ``dx`` and ``dy``.
 
+
+.. _curvature-on:
+
+2.1.2.3 Evaluating curvature on average surface vs. per-frame (``curvature_on``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, :class:`~membrane_curvature.base.MembraneCurvature` computes average mean and Gaussian curvature maps as the time average of per-frame curvature maps:
+
+.. math::
+
+   \langle H \rangle = \frac{1}{N_{\text{frames}}} \sum_{i=1}^{N_{\text{frames}}} H_i, \qquad \langle K \rangle = \frac{1}{N_{\text{frames}}} \sum_{i=1}^{N_{\text{frames}}} K_i
+
+Because curvature is a non-linear function of the surface height field :math:`z(x, y)`, evaluating curvature on the time-averaged surface :math:`H(\langle S \rangle)` produces a mathematically distinct result:
+
+.. math::
+
+   \langle H \rangle \neq H(\langle S \rangle), \qquad \langle K \rangle \neq K(\langle S \rangle)
+
+To explicitly choose where curvature is evaluated for :attr:`~membrane_curvature.base.MembraneCurvature.results.average_mean` and :attr:`~membrane_curvature.base.MembraneCurvature.results.average_gaussian`, pass the ``curvature_on`` parameter:
+
+- ``curvature_on='per_frame'``: Evaluates curvature per frame and time-averages the resulting curvature maps (:math:`\langle H \rangle`, :math:`\langle K \rangle`). This retains the mean contribution of instantaneous thermal fluctuations.
+- ``curvature_on='average_surface'``: Time-averages the surface height field first (:attr:`~membrane_curvature.base.MembraneCurvature.results.average_z_surface`), and evaluates curvature on that average surface (:math:`H(\langle S \rangle)`, :math:`K(\langle S \rangle)`). Thermal fluctuations cancel out over the trajectory, isolating the curvature of the persistent equilibrium membrane shape.
+- ``curvature_on=None`` (default): Resolves to ``'per_frame'`` when ``fft_filter=None``, and ``'average_surface'`` when ``fft_filter`` is enabled.
+
+.. code-block:: python
+
+    import MDAnalysis as mda
+    from membrane_curvature.base import MembraneCurvature
+    from MDAnalysis.tests.datafiles import Martini_membrane_gro
+
+    universe = mda.Universe(Martini_membrane_gro)
+
+    # 1. Time average of per-frame curvatures <H> and <K> (curvature_on='per_frame')
+    mc_fluct = MembraneCurvature(universe,
+                                 select='resid 1-225 and name PO4',
+                                 surface_method='binning',
+                                 n_x_bins=8,
+                                 n_y_bins=8,
+                                 curvature_on='per_frame',
+                                 ).run()
+
+    H_avg = mc_fluct.results.average_mean       # <H>
+    K_avg = mc_fluct.results.average_gaussian   # <K>
+
+    # 2. Curvature of the time-averaged surface H(<S>) and K(<S>) (curvature_on='average_surface')
+    mc_shape = MembraneCurvature(universe,
+                                 select='resid 1-225 and name PO4',
+                                 surface_method='binning',
+                                 n_x_bins=8,
+                                 n_y_bins=8,
+                                 curvature_on='average_surface',
+                                 ).run()
+
+    H_of_S = mc_shape.results.average_mean      # H(<S>)
+    K_of_S = mc_shape.results.average_gaussian  # K(<S>)
+
 .. _membrane-protein:
 
 2.2 Membrane-protein systems


### PR DESCRIPTION
Fixes #252

### Description
Updated Sphinx documentation to reflect the `curvature_on` keyword argument added in #250. Explains the distinction between evaluating curvature on the time-averaged surface ($H(\langle S \rangle)$, $K(\langle S \rangle)$) versus time-averaging per-frame curvature maps ($\langle H \rangle$, $\langle K \rangle$), and provides practical code examples illustrating the usage of `curvature_on`.

### Changes made in this Pull Request:
- **`docs/source/pages/Algorithm.rst`**: Expanded Section 4 ("Average over frames") to document `curvature_on` parameter options (`'per_frame'`, `'average_surface'`, `None`) and added sub-sections explaining the mathematical non-linearity $\langle H \rangle \neq H(\langle S \rangle)$ and $\langle K \rangle \neq K(\langle S \rangle)$.
- **`docs/source/pages/Usage.rst`**: Added Section 2.1.2.3 explaining `curvature_on` with equations and runnable Python code examples comparing per-frame curvature averaging vs. average surface curvature evaluation.
- **`docs/api.rst`**: Updated the API overview and Curvature section notes to reference the `curvature_on` keyword argument.

### PR Checklist
- [x] Issue raised/referenced?
- [N/A] Tests updated/added?
- [x] Documentation updated/added?
- [x] CHANGELOG file updated?