### PR TITLE
CI: Slow cadence of dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "sunday"
       time: "18:00"
     cooldown:
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "saturday"
       time: "18:00"
     groups:


### PR DESCRIPTION
<!--
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->

## Description
<!--
Provide a brief description of the PR's purpose here.
-->
Dependabot PRs are a bit too frequent. Slowing the cadence for both actions and dependencies.

Note that dependabot security updates are raised as soon as a vulnerability with a fix is disclosed, independent of your schedule and separate from your version-update groups (source: [Github blog post](https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/#h-but-what-about-security-updates))

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use a bullet list. -->
- Changed cadence from weekly to monthly.

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [n/a] Issue raised/referenced?
 - [N/a] Tests updated/added?
 - [N/a] Documentation updated/added?
 - [N/a] `CHANGELOG` file updated?
