### PR TITLE
Bug: Calculate analytic derivatives for fourier when `curvature_on='average_surface'` 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Membranecurvature CHANGELOG
 
 ---
 
+* Calculate analytic derivatives for curvature calculations in Fourier surface method for
+  ``curvature_on='average_surface'``. (PR #272)
 * Improve API documentation: MembraneCurvature class docstring (PR #258), move optional params to subsection
   in surface methods and simplify Fourier docstrings (PR #241)
 * Expose and document ``nyquist_q`` to set manual FFT filter bounds (PR #241)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,12 +4,12 @@ Membranecurvature CHANGELOG
 ---
 
 * Calculate analytic derivatives for curvature calculations in Fourier surface method for
-  ``curvature_on='average_surface'``. (PR #272)
+  ``curvature_on='average_surface'`` (PR #272)
 * Improve API documentation: MembraneCurvature class docstring (PR #258), move optional params to subsection
   in surface methods and simplify Fourier docstrings (PR #241)
 * Expose and document ``nyquist_q`` to set manual FFT filter bounds (PR #241)
 * Enabled ``curvature_on`` kwarg to calculate curvature as ``per-frame`` average or as
-  ``'average_surface'``.
+  ``'average_surface'`` (PR #250)
 * Added ``surface_method='binning_nearest'`` as a new surface method (PR #246)
 * Feature: Added periodic edge padding for the binning surface method (PR #238)
 * Refactored binning surface method to use ``np.add.at`` for improved performance (PR #240)

--- a/docs/api/curvature/curvature.rst
+++ b/docs/api/curvature/curvature.rst
@@ -1,2 +1,38 @@
 .. automodule:: membrane_curvature.curvature
-   :members:
+   :no-members:
+
+.. _numerical_derivatives:
+
+Numerical derivatives
+^^^^^^^^^^^^^^^^^^^^^
+
+Functions called to calculate curvature when running the binning methods: ``'binning'``,
+``'binning_nearest'``.
+
+.. autofunction:: mean_curvature
+.. autofunction:: gaussian_curvature
+
+With optional padding (``padding=True``), curvature is calculated numerically on the padded
+surface with:
+
+.. autofunction:: curvature_from_primary_with_edge_pad
+.. autofunction:: curvature_with_edge_pad
+
+.. _analytic_derivatives:
+
+Analytic derivatives
+^^^^^^^^^^^^^^^^^^^^
+
+Functions called to calculate curvature when running the Fourier surface method.
+
+.. autofunction:: fourier_curvature
+.. autofunction:: fourier_curvature_from_coefficients
+.. autofunction:: fourier_curvature_from_theta
+
+Helpers
+^^^^^^^
+
+Monge gauge formulas from precomputed partial derivatives.
+
+.. autofunction:: mean_curvature_monge
+.. autofunction:: gaussian_curvature_monge

--- a/membrane_curvature/base.py
+++ b/membrane_curvature/base.py
@@ -54,6 +54,7 @@ from .curvature import (
     mean_curvature,
     gaussian_curvature,
     fourier_curvature,
+    fourier_curvature_from_theta,
     curvature_from_primary_with_edge_pad,
     curvature_with_edge_pad,
 )
@@ -63,7 +64,10 @@ from .padding import (
 )
 from .padding_validators import validate_edge_pad_bins, validate_orthorhombic
 from .fft_filtering import apply_fft_filter, resolve_fft_filter
-from .fourier_surface import n_fourier_parameters
+from .fourier_surface import (
+    n_fourier_parameters,
+    fourier_mode_list,
+)
 from .fourier_validators import validate_positive_bin_counts
 
 from MDAnalysis.analysis.base import AnalysisBase
@@ -456,6 +460,15 @@ class MembraneCurvature(AnalysisBase):
         self.results.z_surface = np.full((self.n_frames, self.n_x_bins, self.n_y_bins), np.nan)
         self.results.mean = np.full((self.n_frames, self.n_x_bins, self.n_y_bins), np.nan)
         self.results.gaussian = np.full((self.n_frames, self.n_x_bins, self.n_y_bins), np.nan)
+        self._fourier_theta_sum = None
+        self._fourier_modes = None
+        if self.surface_method == self.SurfaceMethod.FOURIER and self.curvature_on == self.CurvatureOn.AVERAGE_SURFACE:
+            self._fourier_modes = fourier_mode_list(self.fourier_m, self.fourier_n)
+            self._fourier_theta_sum = np.zeros(
+                n_fourier_parameters(self.fourier_m, self.fourier_n),
+                dtype=np.float64,
+            )
+            self._fourier_theta_n_finite = 0
 
     def _single_frame(self):
         if self.surface_method == self.SurfaceMethod.BINNING:
@@ -517,7 +530,7 @@ class MembraneCurvature(AnalysisBase):
                 self.results.mean[self._frame_index] = mean_curvature(z_surface, frame_dx, frame_dy)
                 self.results.gaussian[self._frame_index] = gaussian_curvature(z_surface, frame_dx, frame_dy)
         else:
-            z_f, mean_f, gauss_f = fourier_curvature(
+            z_f, mean_f, gauss_f, theta = fourier_curvature(
                 self.ag.positions,
                 self.x_range,
                 self.y_range,
@@ -526,12 +539,54 @@ class MembraneCurvature(AnalysisBase):
                 self.fourier_m,
                 self.fourier_n,
                 rcond=self.fourier_rcond,
+                return_theta=True,
             )
+            if self.curvature_on == self.CurvatureOn.AVERAGE_SURFACE and np.all(np.isfinite(theta)):
+                self._fourier_theta_sum += theta
+                self._fourier_theta_n_finite += 1
             self.results.z_surface[self._frame_index] = z_f
             self.results.mean[self._frame_index] = mean_f
             self.results.gaussian[self._frame_index] = gauss_f
 
     def _conclude(self):
+        if self.surface_method == self.SurfaceMethod.FOURIER and self.curvature_on == self.CurvatureOn.AVERAGE_SURFACE:
+            n_kept = self._fourier_theta_n_finite
+            n_dropped = self.n_frames - n_kept
+            if n_kept == 0:
+                warnings.warn(
+                    f'All {self.n_frames} frames were excluded from the average '
+                    'surface because their Fourier fit did not produce valid '
+                    'coefficients (NaN or infinite values). The average surface '
+                    'and curvature are undefined (NaN).',
+                    UserWarning,
+                    stacklevel=2,
+                )
+                avg_theta = np.full_like(self._fourier_theta_sum, np.nan)
+            else:
+                if n_dropped:
+                    warnings.warn(
+                        f'{n_dropped} of {self.n_frames} frames were excluded from the '
+                        'average surface because their Fourier fit did not produce valid '
+                        f'coefficients (NaN or infinite values). The average curvature is '
+                        f'computed from the remaining {n_kept} frames.',
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                avg_theta = self._fourier_theta_sum / n_kept
+            z_avg, avg_mean, avg_gauss = fourier_curvature_from_theta(
+                avg_theta,
+                self._fourier_modes,
+                self.x_range,
+                self.y_range,
+                self.n_x_bins,
+                self.n_y_bins,
+            )
+            # Same averaged coefficients for height and analytic curvature.
+            self.results.average_z_surface = z_avg
+            self.results.average_mean = avg_mean
+            self.results.average_gaussian = avg_gauss
+            return
+
         z_average = np.nanmean(self.results.z_surface, axis=0)
         if self._fft_q_bounds is not None:
             self.results.average_z_surface = apply_fft_filter(z_average, self.dx, self.dy, self._fft_q_bounds)

--- a/membrane_curvature/base.py
+++ b/membrane_curvature/base.py
@@ -563,6 +563,7 @@ class MembraneCurvature(AnalysisBase):
                 )
                 avg_theta = np.full_like(self._fourier_theta_sum, np.nan)
             else:
+                assert self._fourier_theta_sum is not None
                 if n_dropped:
                     warnings.warn(
                         f'{n_dropped} of {self.n_frames} frames were excluded from the '

--- a/membrane_curvature/curvature.py
+++ b/membrane_curvature/curvature.py
@@ -1,93 +1,79 @@
 r"""
 
 --------------------
-Curvature
+Monge gauge formulas
 --------------------
 
-In MembraneCurvature, we calculate curvature from a height field :math:`z = f(x,y)`
-using the Monge gauge formulas, where partial derivatives are estimated from the
-derived surface.
+In MembraneCurvature, we calculate curvature from a derived surface
+:math:`z = f(x,y)` using the Monge gauge formulas. Partial derivatives of the
+surface are obtained numerically or analytically, depending on the surface
+method.
 
 With the Monge gauge formulas, we map first derivatives :math:`(\partial_x, \partial_y)`, and second
 and mixed derivatives :math:`(\partial_{xx}, \partial_{yy}, \partial_{xy})` to the definitions of
-curvature.
+curvature:
 
-Mean curvature :math:`H`, defined by:
+.. _mean_curvature_formula:
+
+Mean curvature (:math:`H`)
+--------------------------
+
+Defined by:
 
 .. math:: H =
     \frac{(1+\partial_x^2)\partial_{yy}+(1+\partial_y^2)\partial_{xx}-2\partial_x\partial_y\partial_{xy}}
-    {2(1+\partial_x^2+\partial_y^2)^{3/2}},
+    {2(1+\partial_x^2+\partial_y^2)^{3/2}}.
 
-and Gaussian curvature :math:`K`, defined by:
+.. _gaussian_curvature_formula:
+
+Gaussian curvature (:math:`K`)
+------------------------------
+
+Defined by:
 
 .. math:: K = \frac{\partial_{xx}\partial_{yy}-\partial_{xy}^2}
    {(1+\partial_x^2+\partial_y^2)^2}.
 
+In general, units of mean curvature are [length] :sup:`-1`,
+and units of Gaussian curvature are [length] :sup:`-2`.
+Mean curvature is the arithmetic mean of the two principal curvatures. The
+default units of :math:`H` are Å\ :sup:`-1`.
+Gaussian curvature is the product of the two principal curvatures. The
+default units of :math:`K` are Å\ :sup:`-2`.
 
 The Monge gauge formulas are implemented separately in the helpers
 :func:`mean_curvature_monge` and :func:`gaussian_curvature_monge`, which accept
 precomputed partial derivatives as arguments. This approach intends to separate the
-curvature algebra from the derivative estimation.
+curvature algebra from how the derivatives are obtained.
 
-To estimate partial derivatives, we use :func:`mean_curvature` and :func:`gaussian_curvature`
-from the discrete height field using :func:`numpy.gradient`, then pass them to the
-Monge gauge functions above. Optional spacing arguments (``dx``, ``dy``) are
-forwarded to :func:`numpy.gradient` for physical-unit calculations.
+.. important::
 
-Since the mean curvature calculates the arithmetic mean of two
-principal curvatures, the default units of :math:`H` are Å\ :sup:`-1`.
-On the other hand, Gaussian curvature calculates the geometric mean of the
-two principal curvatures. Therefore, the default units of :math:`K` are Å\ :sup:`-2`.
-In general, units of mean curvature are [length] :sup:`-1`,
-and units of Gaussian curvature are [length] :sup:`-2`.
+    Depending on the :attr:`~membrane_curvature.base.MembraneCurvature.surface_method`
+    selected, partial derivatives are obtained in two ways:
 
-.. note::
+    - :ref:`numerical_derivatives` calculate curvature from the discrete surface using
+      :func:`numpy.gradient`, then call the Monge gauge formulas.
 
-    When spacing is provided to :func:`numpy.gradient` (for example, ``dx`` and
-    ``dy`` from the simulation box and grid definition), curvature calculations are
-    performed in physical units and are less sensitive to grid bin count than with
-    implicit unit spacing. However, results are not exactly bin-independent because
-    finite-difference discretization error increases for coarse grids.
+    - :ref:`analytic_derivatives` calculate curvature from analytic derivatives of the
+      fitted Fourier series.
 
-.. warning::
-
-    Numpy cannot calculate the gradient for arrays with inner array of
-    `length==1` unless `axis=0` is specified. Therefore in the functions here included
-    for mean and Gaussian curvature, shape of arrays must be at least (2,2).
-    In general, to calculate a numerical gradients shape of arrays must be >=(`edge_order` +
-    1).
-
-For a periodic **Fourier** fit to atom heights, use
-:func:`~membrane_curvature.fourier_surface.fourier_height_from_atoms` or
-:func:`~membrane_curvature.fourier_surface.fourier_height_derivatives_from_atoms`
-(surface only in :mod:`~membrane_curvature.fourier_surface`), then
-:func:`fourier_curvature` for Monge :math:`H` and :math:`K`
-in one call.
-
-For binning with ``padding=True``, curvature is evaluated with
-:func:`curvature_with_edge_pad`.
-
-
-Functions
----------
-
+For details on curvature calculation, check the :ref:`algorithm` page.
 """
 
 import numpy as np
 
-from .fourier_surface import fourier_height_derivatives_from_atoms
+from .fourier_surface import (
+    _bin_centre_mesh,
+    _eval_fourier_surface,
+    _fourier_fit_from_atoms,
+    _unpack_coefficients,
+)
 from .padding import clip_padded_grid
 
 
 def mean_curvature_monge(fx, fy, fxx, fyy, fxy):
     r"""
-    Helper to calculate mean curvature :math:`H` from partial derivatives of :math:`z = f(x, y)`.
-
-    Same expression as in :func:`mean_curvature` once first derivatives
-    :math:`(\partial_x, \partial_y)` and second and mixed derivatives
-    :math:`(\partial_{xx}, \partial_{yy}, \partial_{xy})` of :math:`z` are known,
-    supplied as ``fx``, ``fy``, ``fxx``, ``fyy``, ``fxy`` (see the module equations
-    above). This function does not compute gradients.
+    Helper to calculate :ref:`mean_curvature_formula` from partial derivatives of :math:`z = f(x, y)`.
 
     Parameters
     ----------
@@ -115,13 +101,7 @@ def mean_curvature_monge(fx, fy, fxx, fyy, fxy):
 
 def gaussian_curvature_monge(fx, fy, fxx, fyy, fxy):
     r"""
-    Helper to calculate Gaussian curvature :math:`K` from partial derivatives of :math:`z = f(x, y)`.
-
-    Same expression as in :func:`gaussian_curvature` once first derivatives
-    :math:`(\partial_x, \partial_y)` and second and mixed derivatives
-    :math:`(\partial_{xx}, \partial_{yy}, \partial_{xy})` of :math:`z` are known,
-    supplied as ``fx``, ``fy``, ``fxx``, ``fyy``, ``fxy`` (see the module equations
-    above). This function does not compute gradients.
+    Helper to calculate :ref:`gaussian_curvature_formula` from partial derivatives of :math:`z = f(x, y)`.
 
     Parameters
     ----------
@@ -145,6 +125,158 @@ def gaussian_curvature_monge(fx, fy, fxx, fyy, fxy):
     return (fxx * fyy - (fxy**2)) / (1 + (fx**2) + (fy**2)) ** 2
 
 
+def gaussian_curvature(Z, *varargs):
+    """
+    Calculate :ref:`gaussian_curvature_formula` from a surface array.
+
+    Partial derivatives are estimated with :func:`numpy.gradient` and passed to
+    :func:`gaussian_curvature_monge`.
+
+    Parameters
+    ----------
+    Z : np.ndarray
+        Surface array of shape ``(n_x_bins, n_y_bins)``.
+    *varargs : list of scalar or array, optional
+        Spacing between values. Default unitary spacing for all dimensions.
+        See :func:`numpy.gradient` for more information.
+
+    Returns
+    -------
+    K : np.ndarray
+        Gaussian curvature, shape ``(n_x_bins, n_y_bins)``.
+
+    """
+
+    Zx, Zy = np.gradient(Z, *varargs)
+    Zxx, Zxy = np.gradient(Zx, *varargs)
+    _, Zyy = np.gradient(Zy, *varargs)
+
+    return gaussian_curvature_monge(Zx, Zy, Zxx, Zyy, Zxy)
+
+
+def mean_curvature(Z, *varargs):
+    """
+    Calculate :ref:`mean_curvature_formula` from a surface array.
+
+    Partial derivatives are estimated with :func:`numpy.gradient` and passed to
+    :func:`mean_curvature_monge`.
+
+    Parameters
+    ----------
+    Z : np.ndarray
+        Surface array of shape ``(n_x_bins, n_y_bins)``.
+    *varargs : list of scalar or array, optional
+        Spacing between values. Default unitary spacing for all dimensions.
+        See :func:`numpy.gradient` for more information.
+
+    Returns
+    -------
+    H : np.ndarray
+        Mean curvature, shape ``(n_x_bins, n_y_bins)``.
+
+    """
+
+    (
+        Zx,
+        Zy,
+    ) = np.gradient(Z, *varargs)
+    Zxx, Zxy = np.gradient(Zx, *varargs)
+    _, Zyy = np.gradient(Zy, *varargs)
+
+    return mean_curvature_monge(Zx, Zy, Zxx, Zyy, Zxy)
+
+
+def fourier_curvature_from_coefficients(
+    A00,
+    coeffs,
+    x_range,
+    y_range,
+    n_x_bins,
+    n_y_bins,
+):
+    r"""
+    Calculate the surface and mean and Gaussian curvature from Fourier
+    coefficients.
+
+    Partial derivatives are obtained analytically from the fitted series and
+    passed to :func:`mean_curvature_monge` and :func:`gaussian_curvature_monge`.
+
+    Parameters
+    ----------
+    A00 : float
+        Mean term :math:`A_{00}`.
+    coeffs : dict
+        Mapping ``(m, n) -> (A, B)`` cosine and sine coefficients per mode.
+    x_range, y_range : tuple of float
+        ``(min, max)`` domain extents.
+    n_x_bins, n_y_bins : int
+        Output grid size at bin centres.
+
+    Returns
+    -------
+    z_surface, mean_H, gaussian_K : ndarray
+        Each array has shape ``(n_x_bins, n_y_bins)``.
+    """
+    box_length_x = x_range[1] - x_range[0]
+    box_length_y = y_range[1] - y_range[0]
+    x_rel, y_rel = _bin_centre_mesh(box_length_x, box_length_y, n_x_bins, n_y_bins)
+    z_surface, fx, fy, fxx, fyy, fxy = _eval_fourier_surface(
+        x_rel,
+        y_rel,
+        box_length_x,
+        box_length_y,
+        A00,
+        coeffs,
+        derivatives=True,
+    )
+    mean_H = mean_curvature_monge(fx, fy, fxx, fyy, fxy)
+    gaussian_K = gaussian_curvature_monge(fx, fy, fxx, fyy, fxy)
+    return z_surface, mean_H, gaussian_K
+
+
+def fourier_curvature_from_theta(
+    theta,
+    modes,
+    x_range,
+    y_range,
+    n_x_bins,
+    n_y_bins,
+):
+    r"""
+    Calculate the surface and mean and Gaussian curvature from a Fourier
+    coefficient vector :math:`\theta`.
+
+    Splits :math:`\theta` with :func:`~membrane_curvature.fourier_surface._unpack_coefficients`
+    and calls :func:`fourier_curvature_from_coefficients`.
+
+    Parameters
+    ----------
+    theta : ndarray, shape (n_coefficients,)
+        Least-squares coefficient vector with mean at index 0, then pairs
+        :math:`(A_{mn}, B_{mn})` in the same order as ``modes``.
+    modes : list of tuple of int
+        Mode list from :func:`~membrane_curvature.fourier_surface.fourier_mode_list`.
+    x_range, y_range : tuple of float
+        ``(min, max)`` domain extents.
+    n_x_bins, n_y_bins : int
+        Output grid size at bin centres.
+
+    Returns
+    -------
+    z_surface, mean_H, gaussian_K : ndarray
+        Each array has shape ``(n_x_bins, n_y_bins)``.
+    """
+    A00, coeffs = _unpack_coefficients(theta, modes)
+    return fourier_curvature_from_coefficients(
+        A00,
+        coeffs,
+        x_range,
+        y_range,
+        n_x_bins,
+        n_y_bins,
+    )
+
+
 def fourier_curvature(
     positions,
     x_range,
@@ -154,12 +286,14 @@ def fourier_curvature(
     M,
     N,
     rcond=None,
+    return_theta=False,
 ):
-    """
-    Bin-centre height and Monge mean / Gaussian curvature from a Fourier fit to atoms.
+    r"""
+    Calculate the surface and mean and Gaussian curvature from a Fourier fit to
+    atom positions.
 
-    Runs :func:`~membrane_curvature.fourier_surface.fourier_height_derivatives_from_atoms`
-    once, then :func:`mean_curvature_monge` and :func:`gaussian_curvature_monge`.
+    Fits coefficients with :func:`~membrane_curvature.fourier_surface._fourier_fit_from_atoms`
+    and calls :func:`fourier_curvature_from_coefficients`.
 
     Parameters
     ----------
@@ -175,123 +309,67 @@ def fourier_curvature(
     rcond : float or None, optional
         Passed to singular-value truncation for the Fourier fit.
         See :func:`~membrane_curvature.fourier_surface._solve_design_least_squares_svd`.
+    return_theta : bool, optional
+        If ``True``, also return the coefficient vector :math:`\theta`.
 
     Returns
     -------
     z_surface, mean_H, gaussian_K : ndarray
         Each array has shape ``(n_x_bins, n_y_bins)``.
+    theta : ndarray, optional
+        Coefficient vector. Returned only when ``return_theta`` is ``True``.
 
     Warns
     -----
     UserWarning
         If the Fourier least-squares system is rank-deficient or underdetermined.
     """
-    Z, fx, fy, fxx, fyy, fxy = fourier_height_derivatives_from_atoms(
+    _box_length_x, _box_length_y, A00, coeffs, theta = _fourier_fit_from_atoms(
         positions,
         x_range,
         y_range,
-        n_x_bins,
-        n_y_bins,
         M,
         N,
         rcond=rcond,
     )
-    H = mean_curvature_monge(fx, fy, fxx, fyy, fxy)
-    K = gaussian_curvature_monge(fx, fy, fxx, fyy, fxy)
-    return Z, H, K
-
-
-def gaussian_curvature(Z, *varargs):
-    """
-    Calculate Gaussian curvature from Z cloud points.
-
-    Uses :func:`numpy.gradient` on `Z`, then :func:`gaussian_curvature_monge`.
-
-    Parameters
-    ----------
-    Z: np.ndarray.
-        Multidimensional array of shape (n,n).
-    varargs : list of scalar or array, optional
-        Spacing between f values. Default unitary spacing for all dimensions.
-        See np.gradient docs for more information.
-
-    Returns
-    -------
-    K : np.ndarray.
-        The result of Gaussian curvature of Z. Returns multidimensional
-        array object with values of Gaussian curvature of shape `(n, n)`.
-
-    """
-
-    Zx, Zy = np.gradient(Z, *varargs)
-    Zxx, Zxy = np.gradient(Zx, *varargs)
-    _, Zyy = np.gradient(Zy, *varargs)
-
-    return gaussian_curvature_monge(Zx, Zy, Zxx, Zyy, Zxy)
-
-
-def mean_curvature(Z, *varargs):
-    """
-    Calculates mean curvature from Z cloud points.
-
-    Uses :func:`numpy.gradient` on `Z`, then :func:`mean_curvature_monge`.
-
-    Parameters
-    ----------
-    Z: np.ndarray.
-        Multidimensional array of shape (n,n).
-    varargs : list of scalar or array, optional
-        Spacing between f values. Default unitary spacing for all dimensions.
-        See np.gradient docs for more information.
-
-    Returns
-    -------
-    H : np.ndarray.
-        The result of mean curvature of Z. Returns multidimensional
-        array object with values of mean curvature of shape `(n, n)`.
-
-    """
-
-    (
-        Zx,
-        Zy,
-    ) = np.gradient(Z, *varargs)
-    Zxx, Zxy = np.gradient(Zx, *varargs)
-    _, Zyy = np.gradient(Zy, *varargs)
-
-    return mean_curvature_monge(Zx, Zy, Zxx, Zyy, Zxy)
+    z_surface, mean_H, gaussian_K = fourier_curvature_from_coefficients(
+        A00,
+        coeffs,
+        x_range,
+        y_range,
+        n_x_bins,
+        n_y_bins,
+    )
+    if return_theta:
+        return z_surface, mean_H, gaussian_K, theta
+    return z_surface, mean_H, gaussian_K
 
 
 def curvature_with_edge_pad(z_surface_padded, dx, dy, edge_pad_bins):
-    """
-    Evaluate Monge curvature on a padded height field and clip to the primary box.
+    r"""
+    Calculate mean and Gaussian curvature from a padded surface and clip the
+    result to the primary box.
 
     Parameters
     ----------
     z_surface_padded : ndarray
-        Height field on the expanded grid, shape
+        Surface on the expanded grid, shape
         ``(n_x_bins + 2*edge_pad_bins, n_y_bins + 2*edge_pad_bins)``.
     dx : float
-        Bin spacing along ``x`` (Å).
+        Bin spacing along :math:`x` (Å).
     dy : float
-        Bin spacing along ``y`` (Å).
+        Bin spacing along :math:`y` (Å).
     edge_pad_bins : int
         Buffer width in bins.
 
     Returns
     -------
     z_surface : ndarray
-        Clipped height, shape ``(n_x_bins, n_y_bins)``.
+        Clipped surface, shape ``(n_x_bins, n_y_bins)``.
     mean : ndarray
         Clipped mean curvature, same shape.
     gaussian : ndarray
         Clipped Gaussian curvature, same shape.
-
-    .. note::
-
-        Function available only when running with ``padding=True``. Finite differences
-        run on the padded array and then clipped to the primary box. Gradients are
-        computed once and shared by mean and Gaussian curvature.
     """
     zx, zy = np.gradient(z_surface_padded, dx, dy)
     zxx, zxy = np.gradient(zx, dx, dy)
@@ -306,34 +384,33 @@ def curvature_with_edge_pad(z_surface_padded, dx, dy, edge_pad_bins):
 
 
 def curvature_from_primary_with_edge_pad(z_surface, dx, dy, edge_pad_bins):
-    """
-    Evaluate Monge curvature on a primary box height field using a wrap-pad buffer.
+    r"""
+    Calculate mean and Gaussian curvature from a primary surface with a periodic
+    buffer.
+
+    Adds a periodic buffer around the primary surface and calls
+    :func:`curvature_with_edge_pad`.
 
     Parameters
     ----------
     z_surface : ndarray
-        Primary height field, shape ``(n_x_bins, n_y_bins)``.
+        Surface in the primary box, shape ``(n_x_bins, n_y_bins)``.
     dx : float
-        Bin spacing along ``x`` (Å).
+        Bin spacing along :math:`x` (Å).
     dy : float
-        Bin spacing along ``y`` (Å).
+        Bin spacing along :math:`y` (Å).
     edge_pad_bins : int
         Buffer width in bins on each side.
 
     Returns
     -------
     z_surface : ndarray
-        Same primary height (clipped identity of the wrap-padded array).
+        The original surface, returned after removing the extra padding added for
+        calculation.
     mean : ndarray
         Mean curvature on the primary grid.
     gaussian : ndarray
         Gaussian curvature on the primary grid.
-
-    Notes
-    -----
-    Used for average maps after optional FFT filtering, when atom images are no
-    longer available and the height field is already periodic on the primary
-    grid. The buffer is built with :func:`numpy.pad` ``mode='wrap'``.
     """
     p = int(edge_pad_bins)
     if p < 1:

--- a/membrane_curvature/fourier_surface.py
+++ b/membrane_curvature/fourier_surface.py
@@ -330,7 +330,7 @@ def _fourier_fit_from_atoms(
     M: int,
     N: int,
     rcond: float | None = None,
-) -> tuple[float, float, float, dict[tuple[int, int], tuple[float, float]]]:
+) -> tuple[float, float, float, dict[tuple[int, int], tuple[float, float]], np.ndarray]:
     r"""
     Fit Fourier coefficients to atom heights, without evaluating on a grid.
 
@@ -359,6 +359,9 @@ def _fourier_fit_from_atoms(
         Mean height coefficient :math:`A_{00}`.
     coeffs : dict[tuple[int, int], tuple[float, float]]
         Mapping ``(m, n) -> (A, B)`` cosine and sine coefficients per mode.
+    theta : ndarray, shape (n_coefficients,)
+        Coefficient vector (index ``0`` is :math:`A_{00}`, then cosine/sine
+        pairs in :func:`fourier_mode_list` order).
 
     Raises
     ------
@@ -398,7 +401,7 @@ def _fourier_fit_from_atoms(
             stacklevel=2,
         )
     A00, coeffs = _unpack_coefficients(theta, modes)
-    return Lx, Ly, A00, coeffs
+    return Lx, Ly, A00, coeffs, theta
 
 
 def _harmonic_height_and_phi_derivatives(
@@ -652,7 +655,7 @@ def fourier_height_from_atoms(
         If the least-squares system is rank-deficient or underdetermined.
     """
     validate_positive_bin_counts(n_x_bins, n_y_bins)
-    Lx, Ly, A00, coeffs = _fourier_fit_from_atoms(
+    Lx, Ly, A00, coeffs, _theta = _fourier_fit_from_atoms(
         positions,
         x_range,
         y_range,
@@ -713,7 +716,7 @@ def fourier_height_derivatives_from_atoms(
         If the least-squares system is rank-deficient or underdetermined.
     """
     validate_positive_bin_counts(n_x_bins, n_y_bins)
-    Lx, Ly, A00, coeffs = _fourier_fit_from_atoms(
+    Lx, Ly, A00, coeffs, _theta = _fourier_fit_from_atoms(
         positions,
         x_range,
         y_range,

--- a/membrane_curvature/tests/test_curvature.py
+++ b/membrane_curvature/tests/test_curvature.py
@@ -1,0 +1,39 @@
+"""Unit tests for Fourier curvature helpers in membrane_curvature.curvature."""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_almost_equal
+
+from membrane_curvature.curvature import (
+    fourier_curvature,
+    fourier_curvature_from_coefficients,
+    fourier_curvature_from_theta,
+)
+from membrane_curvature.fourier_surface import fourier_mode_list
+
+# Dummy domain for testing
+DOMAIN = dict(x_range=(0.0, 2.0), y_range=(0.0, 2.0), n_x_bins=4, n_y_bins=4)
+
+
+def test_flat_surface_has_zero_curvature():
+    z, H, K = fourier_curvature_from_coefficients(A00=12.5, coeffs={}, **DOMAIN)
+    assert_almost_equal(z, np.full_like(z, 12.5))
+    assert_almost_equal(H, np.zeros_like(z))
+    assert_almost_equal(K, np.zeros_like(z))
+
+
+@pytest.fixture()
+def single_cosine_fit():
+    xs = np.linspace(0.0, 2.0, 4, endpoint=False)
+    xx, yy = np.meshgrid(xs, xs, indexing='ij')
+    zz = 9.0 + 0.5 * np.cos(np.pi * xx)
+    positions = np.column_stack([xx.ravel(), yy.ravel(), zz.ravel()])
+    z, H, K, theta = fourier_curvature(positions, **DOMAIN, M=1, N=0, return_theta=True)
+    return theta, (z, H, K)
+
+
+def test_from_theta_matches_fourier_curvature_fit(single_cosine_fit):
+    theta, expected = single_cosine_fit
+    result = fourier_curvature_from_theta(theta, fourier_mode_list(1, 0), **DOMAIN)
+    for got, exp in zip(result, expected):
+        assert_almost_equal(got, exp)

--- a/membrane_curvature/tests/test_fourier_surface.py
+++ b/membrane_curvature/tests/test_fourier_surface.py
@@ -127,7 +127,7 @@ def rank_deficient_design_system():
 def test_calculate_a00_2x2_grid(dummy_fourier_universe, dummy_fourier_fit):
     """Test A_00 matches np.mean of z coords"""
     expected_A00 = 9  # equivalent to np.mean(positions[:, 2])
-    _box_length_x, _box_length_y, calculated_A_00, _coeffs = dummy_fourier_fit
+    _box_length_x, _box_length_y, calculated_A_00, _coeffs, _theta = dummy_fourier_fit
     assert_almost_equal(calculated_A_00, expected_A00)
 
 
@@ -558,7 +558,7 @@ def test_fourier_height_derivatives_from_atoms(dummy_fourier_universe):
         M=1,
         N=0,
     )
-    Lx, Ly, A00, coeffs = _fourier_fit_from_atoms(
+    Lx, Ly, A00, coeffs, _theta = _fourier_fit_from_atoms(
         positions,
         x_range=(0.0, 2.0),
         y_range=(0.0, 2.0),

--- a/membrane_curvature/tests/test_membrane_curvature.py
+++ b/membrane_curvature/tests/test_membrane_curvature.py
@@ -10,8 +10,9 @@ from numpy.testing import assert_almost_equal
 import MDAnalysis as mda
 from membrane_curvature.tests.datafiles import GRO_PO4_SMALL
 from membrane_curvature.base import MembraneCurvature
-from membrane_curvature.curvature import fourier_curvature
-from membrane_curvature.fourier_surface import n_fourier_parameters
+from MDAnalysis.coordinates.memory import MemoryReader
+from membrane_curvature.curvature import fourier_curvature, fourier_curvature_from_theta
+from membrane_curvature.fourier_surface import fourier_mode_list, n_fourier_parameters
 
 # Reference data from datafile
 MEMBRANE_CURVATURE_DATA = {
@@ -1390,6 +1391,186 @@ class TestMembraneCurvature(object):
             getattr(mc.results, result_attr)[0],
             ref_fields[ref_index],
         )
+
+    def test_fourier_average_surface_uses_analytic_averaged_coefficients(self, universe_dummy_full):
+        mc = MembraneCurvature(
+            universe_dummy_full,
+            select='all',
+            n_x_bins=4,
+            n_y_bins=4,
+            surface_method='fourier',
+            fourier_m=1,
+            fourier_n=1,
+            curvature_on='average_surface',
+        ).run()
+        # Single-frame trajectory: averaged coefficients match the frame fit.
+        assert_almost_equal(mc.results.average_z_surface, mc.results.z_surface[0])
+        assert_almost_equal(mc.results.average_mean, mc.results.mean[0])
+        assert_almost_equal(mc.results.average_gaussian, mc.results.gaussian[0])
+        fd_mean = mean_curvature(mc.results.average_z_surface, mc.dx, mc.dy)
+        assert not np.allclose(mc.results.average_mean, fd_mean)
+
+    def test_fourier_average_surface_multi_frame_accumulates_coefficients(self):
+        frame0 = np.array(
+            [
+                [0.0, 0.0, 150.0],
+                [100.0, 0.0, 150.0],
+                [200.0, 0.0, 150.0],
+                [0.0, 200.0, 150.0],
+                [100.0, 200.0, 120.0],
+                [200.0, 200.0, 120.0],
+                [0.0, 100.0, 120.0],
+                [100.0, 100.0, 120.0],
+                [200.0, 100.0, 120.0],
+            ]
+        )
+        frame1 = frame0.copy()
+        frame1[:, 2] = frame0[:, 2] + np.array([0.0, 5.0, -5.0, 10.0, -10.0, 15.0, -15.0, 20.0, -20.0])
+        universe = mda.Universe(frame0, n_atoms=9)
+        universe.dimensions = [300.0, 300.0, 300.0, 90.0, 90.0, 90.0]
+        universe.load_new(
+            np.stack([frame0, frame1], axis=0),
+            format=MemoryReader,
+            dimensions=np.tile(universe.dimensions, (2, 1)),
+        )
+
+        n_x_bins = n_y_bins = 4
+        fourier_m = fourier_n = 1
+        mc = MembraneCurvature(
+            universe,
+            select='all',
+            n_x_bins=n_x_bins,
+            n_y_bins=n_y_bins,
+            surface_method='fourier',
+            fourier_m=fourier_m,
+            fourier_n=fourier_n,
+            curvature_on='average_surface',
+        ).run()
+        assert mc.n_frames == 2
+
+        # Height is linear in theta, so the averaged surface is the mean of frames.
+        assert_almost_equal(
+            mc.results.average_z_surface,
+            np.mean(mc.results.z_surface, axis=0),
+        )
+
+        x_range = (0.0, universe.dimensions[0])
+        y_range = (0.0, universe.dimensions[1])
+        thetas = []
+        for _ts in universe.trajectory:
+            *_fields, theta = fourier_curvature(
+                universe.atoms.positions,
+                x_range,
+                y_range,
+                n_x_bins,
+                n_y_bins,
+                fourier_m,
+                fourier_n,
+                return_theta=True,
+            )
+            thetas.append(theta)
+        _z, avg_mean, avg_gauss = fourier_curvature_from_theta(
+            np.mean(thetas, axis=0),
+            fourier_mode_list(fourier_m, fourier_n),
+            x_range,
+            y_range,
+            n_x_bins,
+            n_y_bins,
+        )
+        assert_almost_equal(mc.results.average_mean, avg_mean)
+        assert_almost_equal(mc.results.average_gaussian, avg_gauss)
+        # Curvature is nonlinear in theta: not a plain mean of per-frame maps.
+        assert not np.allclose(mc.results.average_mean, np.mean(mc.results.mean, axis=0))
+
+    def test_fourier_average_surface_warns_when_nonfinite_frames_dropped(self):
+        frame0 = np.array(
+            [
+                [0.0, 0.0, 150.0],
+                [100.0, 0.0, 150.0],
+                [200.0, 0.0, 150.0],
+                [0.0, 200.0, 150.0],
+                [100.0, 200.0, 120.0],
+                [200.0, 200.0, 120.0],
+                [0.0, 100.0, 120.0],
+                [100.0, 100.0, 120.0],
+                [200.0, 100.0, 120.0],
+            ]
+        )
+        frame1 = frame0.copy()
+        frame1[0, 2] = np.nan
+        universe = mda.Universe(frame0, n_atoms=9)
+        universe.dimensions = [300.0, 300.0, 300.0, 90.0, 90.0, 90.0]
+        universe.load_new(
+            np.stack([frame0, frame1], axis=0),
+            format=MemoryReader,
+            dimensions=np.tile(universe.dimensions, (2, 1)),
+        )
+        mc = MembraneCurvature(
+            universe,
+            select='all',
+            n_x_bins=4,
+            n_y_bins=4,
+            surface_method='fourier',
+            fourier_m=1,
+            fourier_n=1,
+            curvature_on='average_surface',
+        )
+        with pytest.warns(
+            UserWarning,
+            match=(
+                r'1 of 2 frames were excluded from the average surface because '
+                r'their Fourier fit did not produce valid coefficients'
+            ),
+        ):
+            mc.run()
+        assert mc._fourier_theta_n_finite == 1
+        assert_almost_equal(mc.results.average_z_surface, mc.results.z_surface[0])
+
+    def test_fourier_average_surface_warns_when_all_frames_nonfinite(self):
+        frame = np.array(
+            [
+                [0.0, 0.0, 150.0],
+                [100.0, 0.0, 150.0],
+                [200.0, 0.0, 150.0],
+                [0.0, 200.0, 150.0],
+                [100.0, 200.0, 120.0],
+                [200.0, 200.0, 120.0],
+                [0.0, 100.0, 120.0],
+                [100.0, 100.0, 120.0],
+                [200.0, 100.0, 120.0],
+            ]
+        )
+        frame_bad = frame.copy()
+        frame_bad[0, 2] = np.nan
+        universe = mda.Universe(frame_bad, n_atoms=9)
+        universe.dimensions = [300.0, 300.0, 300.0, 90.0, 90.0, 90.0]
+        universe.load_new(
+            np.stack([frame_bad, frame_bad], axis=0),
+            format=MemoryReader,
+            dimensions=np.tile(universe.dimensions, (2, 1)),
+        )
+        mc = MembraneCurvature(
+            universe,
+            select='all',
+            n_x_bins=4,
+            n_y_bins=4,
+            surface_method='fourier',
+            fourier_m=1,
+            fourier_n=1,
+            curvature_on='average_surface',
+        )
+        with pytest.warns(
+            UserWarning,
+            match=(
+                r'All 2 frames were excluded from the average surface.*'
+                r'undefined \(NaN\)'
+            ),
+        ):
+            mc.run()
+        assert mc._fourier_theta_n_finite == 0
+        assert np.all(np.isnan(mc.results.average_z_surface))
+        assert np.all(np.isnan(mc.results.average_mean))
+        assert np.all(np.isnan(mc.results.average_gaussian))
 
     # --- padding -------------------------------------------------------------
 


### PR DESCRIPTION
<!--
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #270 

## Description
<!--
Provide a brief description of the PR's purpose here.
-->

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use a bullet list. -->
- New test file: test_curvature.py
- Improve API docs - curvature
- Added curvature functions to fix bug.
- In base.py: accumulate per-frame Fourier coefficients, calculate average, then rebuild height and analytic H/K.

## LLM / AI acknowledgement and disclosure
<!-- Please update this disclosure to reflect you acknowledge the MDAnalysis AI Policy and to declare if you did or did not use LLMs / AI to generate code -->
- [x] I have read and understood the [MDAnalysis AI Policy](https://github.com/MDAnalysis/mdanalysis/blob/develop/AI_POLICY.md) that governs this project.
- LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes - review bug is actually fixed.

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [x] Documentation updated/added?
 - [x] LLM/AI disclosure was updated?
 - [x] `CHANGELOG` file updated?
