### PR TITLE
Fix: raise `ValueError` when `fft_filter` runs with the Fourier method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Membranecurvature CHANGELOG
 
 ---
 
+* Raise ValueError when ``fft_filter`` is not None for Fourier method (PR #279)
 * Revamp Usage doc page (PR #276)
 * Update Algorithm doc page with three surface methods and optional padding/FFT filtering (PR #266)
 * Calculate analytic derivatives for curvature calculations in Fourier surface method for

--- a/membrane_curvature/base.py
+++ b/membrane_curvature/base.py
@@ -345,8 +345,8 @@ class MembraneCurvature(AnalysisBase):
         if self.surface_method == self.SurfaceMethod.FOURIER:
             if wrap is True:
                 raise ValueError("wrap=True is only valid when surface_method='binning'")
-            if isinstance(fft_filter, dict):
-                raise ValueError('fft_filter dict is only allowed for binning surface methods')
+            if fft_filter is not None:
+                raise ValueError("fft_filter is only valid for surface_method='binning' or 'binning_nearest'")
             if self.padding:
                 raise ValueError(
                     "padding=True is only valid for surface_method='binning' or surface_method='binning_nearest'"

--- a/membrane_curvature/tests/test_fft_filtering.py
+++ b/membrane_curvature/tests/test_fft_filtering.py
@@ -236,14 +236,15 @@ def test_average_curvature_order_filter_then_curvature():
     assert not np.allclose(correct, wrong)
 
 
-def test_membrane_curvature_fourier_rejects_fft_filter_dict(universe_dummy_wrap):
-    with pytest.raises(ValueError, match='fft_filter dict is only allowed'):
+@pytest.mark.parametrize('fft_filter', ['auto', {'q': (0.0, 0.2)}])
+def test_membrane_curvature_fourier_rejects_fft_filter(universe_dummy_wrap, fft_filter):
+    with pytest.raises(ValueError, match='fft_filter is only valid'):
         MembraneCurvature(
             universe_dummy_wrap,
             surface_method='fourier',
             fourier_m=1,
             fourier_n=1,
-            fft_filter={'q': (0.0, 0.2)},
+            fft_filter=fft_filter,
         )
 
 


### PR DESCRIPTION
<!--
Insert issue number that this PR fixes (if any) just after 'Fixes #'.
If this PR does not fix an existing issue, consider opening one or remove 'Fixes #' from the PR description.
-->
Fixes #277 

## Description
<!--
Provide a brief description of the PR's purpose here.
-->

Changes made in this Pull Request:
<!-- Describe the changes that this PR makes. If applicable, use a bullet list. -->
- Raise ValueError when analysis run with FFT filter and the Fourier method.

## LLM / AI acknowledgement and disclosure
<!-- Please update this disclosure to reflect you acknowledge the MDAnalysis AI Policy and to declare if you did or did not use LLMs / AI to generate code -->
- [x] I have read and understood the [MDAnalysis AI Policy](https://github.com/MDAnalysis/mdanalysis/blob/develop/AI_POLICY.md) that governs this project.
- LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

## PR Checklist
<!-- Please use the following checklist to ensure the PR is ready to be reviewed/merged. -->
 - [x] Issue raised/referenced?
 - [x] Tests updated/added?
 - [N/A] Documentation updated/added?
 - [x] LLM/AI disclosure was updated?
 - [x] `CHANGELOG` file updated?
